### PR TITLE
COMPASS-2914 updated green status indicator

### DIFF
--- a/src/assets/less/compass/variables/_palette.less
+++ b/src/assets/less/compass/variables/_palette.less
@@ -3,13 +3,13 @@
 
 /* MongoDB Color Palette */
 /* commented colors have been deprecated */
-@green0: #365221;
-@green1: #507b32;
-@green2: #67b144;
-@green3: #86bc63;
-@green4: #a6c88e;
-@green5: #c4dbb3;
-@green6: #69AD55;
+@green0: #0E7E3D; 
+@green1: #168B46;
+@green2: #13AA52; // Primary green
+@green3: #1CC061; 
+@green4: #89E5B3;
+@green5: #CCFFE1; 
+@green6: #EFFEF6;
 
 @gray0: #313030;
 @gray1: #494747;
@@ -54,7 +54,7 @@
 @linkText: #006cbc;
 @linkOnDark: #2898dd;
 @warningText: #ffb618;
-@successText: #6ca439;
+@successText: @green2;
 @errorText: #ed271c;
 @mutedText: @gray4;
 @veryMutedText: @gray5;


### PR DESCRIPTION
Updated `palette.less` greens, so `.pipeline-preview-toolbar-indicator` will use `@green2`: `#13AA52`

Note: Colors to be updated **by MongoDB World**