### PR TITLE
COMPASS-2932 Increase Agg Pipeline debounce to 750ms

### DIFF
--- a/src/components/stage-editor/stage-editor.jsx
+++ b/src/components/stage-editor/stage-editor.jsx
@@ -57,7 +57,7 @@ class StageEditor extends PureComponent {
       this.props.stage.stageOperator
     );
     tools.setCompleters([ this.completer ]);
-    this.debounceRun = debounce(this.onRunStage, 500);
+    this.debounceRun = debounce(this.onRunStage, 750);
   }
 
   /**


### PR DESCRIPTION
Increase the debounce on the pipeline running from 500ms to 750ms for the slower typers.