### PR TITLE
COMPASS-2931 Remove $limit in front of $sort

### DIFF
--- a/src/modules/pipeline.js
+++ b/src/modules/pipeline.js
@@ -85,8 +85,7 @@ export const REQUIRED_AS_FIRST_STAGE = [
  * next stage.
  */
 export const FULL_SCAN_OPS = [
-  '$group',
-  '$sort'
+  '$group'
 ];
 
 /**

--- a/src/modules/pipeline.spec.js
+++ b/src/modules/pipeline.spec.js
@@ -448,7 +448,7 @@ describe('pipeline module', () => {
           executor: { $sort: { name: 1 }},
           stageOperator: '$sort'
         };
-        const state = { inputDocuments: { count: 1000000 }, pipeline: [ stage0 ]};
+        const state = { inputDocuments: { count: 100001 }, pipeline: [ stage0 ]};
 
         it('sets the limit on the end', () => {
           expect(generatePipeline(state, 0)).to.deep.equal([

--- a/src/modules/pipeline.spec.js
+++ b/src/modules/pipeline.spec.js
@@ -448,7 +448,7 @@ describe('pipeline module', () => {
           executor: { $sort: { name: 1 }},
           stageOperator: '$sort'
         };
-        const state = { inputDocuments: { count: 100001 }, pipeline: [ stage0 ]};
+        const state = { inputDocuments: { count: 1000000 }, pipeline: [ stage0 ]};
 
         it('sets the limit on the end', () => {
           expect(generatePipeline(state, 0)).to.deep.equal([

--- a/src/modules/pipeline.spec.js
+++ b/src/modules/pipeline.spec.js
@@ -21,6 +21,9 @@ import reducer, {
   LOADING_STAGE_RESULTS,
   STAGE_TOGGLED } from 'modules/pipeline';
 
+const LIMIT_TO_PROCESS = 100000;
+const LIMIT_TO_DISPLAY = 20;
+
 describe('pipeline module', () => {
   describe('#reducer', () => {
     context('when the action is undefined', () => {
@@ -344,7 +347,7 @@ describe('pipeline module', () => {
   });
 
   describe('#generatePipeline', () => {
-    const limit = { $limit: 20 };
+    const limit = { $limit: LIMIT_TO_DISPLAY };
 
     context('when the index is the first', () => {
       const stage = { isEnabled: true, executor: { $match: { name: 'test' }}};
@@ -417,7 +420,7 @@ describe('pipeline module', () => {
         const stage0 = { isEnabled: true, executor: { $match: { name: 'test' }}};
         const state = { inputDocuments: { count: 1000000 }, pipeline: [ stage0 ]};
 
-        it('sets the limit on the end', () => {
+        it(`sets only the ${LIMIT_TO_DISPLAY} limit on the end`, () => {
           expect(generatePipeline(state, 0)).to.deep.equal([
             stage0.executor,
             limit
@@ -433,9 +436,9 @@ describe('pipeline module', () => {
         };
         const state = { inputDocuments: { count: 1000000 }, pipeline: [ stage0 ]};
 
-        it('sets the limit on the end', () => {
+        it(`sets the ${LIMIT_TO_PROCESS} limit before $group and the ${LIMIT_TO_DISPLAY} limit on the end`, () => {
           expect(generatePipeline(state, 0)).to.deep.equal([
-            { $limit: 100000 },
+            { $limit: LIMIT_TO_PROCESS },
             stage0.executor,
             limit
           ]);
@@ -450,7 +453,7 @@ describe('pipeline module', () => {
         };
         const state = { inputDocuments: { count: 1000000 }, pipeline: [ stage0 ]};
 
-        it('sets the limit on the end', () => {
+        it(`sets only the ${LIMIT_TO_DISPLAY} limit on the end`, () => {
           expect(generatePipeline(state, 0)).to.deep.equal([
             stage0.executor,
             limit

--- a/src/modules/pipeline.spec.js
+++ b/src/modules/pipeline.spec.js
@@ -452,7 +452,6 @@ describe('pipeline module', () => {
 
         it('sets the limit on the end', () => {
           expect(generatePipeline(state, 0)).to.deep.equal([
-            { $limit: 100000 },
             stage0.executor,
             limit
           ]);


### PR DESCRIPTION
Remove the $limit in the aggregation pipeline being added before a $sort as it will prevent index usage.