### PR TITLE
COMPASS-2929 - Increase Document Height Dynamically with Expression Editor Height

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2788,7 +2788,7 @@
     },
     "compression": {
       "version": "1.7.2",
-      "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
       "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
       "dev": true,
       "requires": {
@@ -4817,7 +4817,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "requires": {
         "duplexer": "0.1.1",
@@ -14159,7 +14159,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },

--- a/src/components/stage-editor/stage-editor.less
+++ b/src/components/stage-editor/stage-editor.less
@@ -9,6 +9,7 @@
   background: @gray8;
   border-left: 2px solid @gray10;
   width: 350px;
+  min-height: 180px;
 
   &-errormsg {
     flex-shrink: 0;

--- a/src/components/stage-preview/stage-preview.less
+++ b/src/components/stage-preview/stage-preview.less
@@ -43,7 +43,7 @@
       .document {
         background-color: @pw;
         margin: 10px;
-        padding: 0px 20px;
+        padding: 0;
         border: 1px solid @gray6;
         border-radius: 4px;
         box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.1);
@@ -60,6 +60,7 @@
           flex-grow: 1;
           flex-shrink: 0;
           overflow: auto;
+          padding: 20px;
         }
 
         &-elements {

--- a/src/components/stage-preview/stage-preview.less
+++ b/src/components/stage-preview/stage-preview.less
@@ -3,7 +3,7 @@
 .stage-preview {
   width: 100%;
   display: flex;
-  align-items: center;
+  align-items: stretch;
   overflow: auto;
 
   &-invalid {
@@ -34,7 +34,7 @@
 
   &-documents {
     display: flex;
-    align-items: flex-start;
+    align-items: stretch;
     overflow-x: scroll;
     margin: 15px;
 
@@ -47,7 +47,7 @@
         border-radius: 4px;
         box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.1);
         width: 350px;
-        height: 150px;
+        min-height: 150px;
         overflow: scroll;
         flex-shrink: 0;
         z-index: 100;

--- a/src/components/stage-preview/stage-preview.less
+++ b/src/components/stage-preview/stage-preview.less
@@ -8,6 +8,7 @@
 
   &-invalid {
     padding-left: 15px;
+    margin: auto;
   }
 
   &-out {
@@ -51,6 +52,15 @@
         overflow: scroll;
         flex-shrink: 0;
         z-index: 100;
+        display: flex;
+        flex-direction: column;
+
+        &-contents {
+          flex-basis: 150px;
+          flex-grow: 1;
+          flex-shrink: 0;
+          overflow: auto;
+        }
 
         &-elements {
           padding: 0px;

--- a/src/components/stage-workspace/stage-workspace.less
+++ b/src/components/stage-workspace/stage-workspace.less
@@ -1,5 +1,5 @@
 .stage-workspace {
   display: flex;
-  align-items: center;
+  align-items: stretch;
   border-radius: 0 0 4px 4px;
 }


### PR DESCRIPTION
@durran This should allow documents in preview area to expand to parent's full height when code editor height has been increased:

![compass-2929](https://user-images.githubusercontent.com/489217/41435822-ffbb83c4-6fed-11e8-9bc4-507c22f9130e.gif)

Might be nice if the document height only increased if it needed to in order to accommodate fields not shown... but I think this does the job of at least allowing the height to match the code editor height which prevents a bad experience for those cases with document results with large number of fields.

cc @sampoonachot 