### PR TITLE
COMPASS-3049 - Cannot see buttons with really long saved pipeline

### DIFF
--- a/src/components/save-pipeline-card/save-pipeline-card.less
+++ b/src/components/save-pipeline-card/save-pipeline-card.less
@@ -21,5 +21,7 @@
     font-weight: bold;
     flex-grow: 5;
     color: @gray1;
+    overflow-wrap: break-word;
+    overflow: auto;
   }
 }


### PR DESCRIPTION
The name now wraps before the buttons start:

<img width="546" alt="screen shot 2018-08-21 at 5 22 34 pm" src="https://user-images.githubusercontent.com/1045019/44411474-de528f80-a566-11e8-8aee-3c477f17444c.png">

Or, if not moused over,
<img width="548" alt="screen shot 2018-08-21 at 5 22 23 pm" src="https://user-images.githubusercontent.com/1045019/44411502-f0343280-a566-11e8-930e-c284001dd154.png">

