### PR TITLE
COMPASS-3297: Fix long error messages being hidden

### DIFF
--- a/src/components/stage-editor/stage-editor.less
+++ b/src/components/stage-editor/stage-editor.less
@@ -19,9 +19,9 @@
     border-radius: 3px;
     overflow: hidden;
     background: #ff473a;
-    height: 20px;
+    min-height: 20px;
     width: 350px;
-    white-space: nowrap;
+    word-break: break-all;
     color: @gray8;
     font-size: x-small;
     font-weight: bold;
@@ -35,9 +35,9 @@
     border-radius: 3px;
     overflow: hidden;
     background: @warningText;
-    height: 20px;
+    min-height: 20px;
     width: 350px;
-    white-space: nowrap;
+    word-break: break-all;
     color: @gray8;
     font-size: x-small;
     font-weight: bold;


### PR DESCRIPTION
### Before
![screenshot 2018-12-19 13 52 56](https://user-images.githubusercontent.com/23074/50241550-bef13500-0395-11e9-8610-ee64329052e6.png)

### After
![screenshot 2018-12-19 13 31 56](https://user-images.githubusercontent.com/23074/50241580-d3cdc880-0395-11e9-8445-dd506cfb785f.png)
