### PR TITLE
[discussion] Aggregations in the Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,22 @@ conveniently set any values it uses.
 ### Browser
 
 ```js
-import Plugin, { initStore } from '@mongodb-js/compass-aggregations';
+import Plugin, {
+  configureStore,
+  refreshInput,
+  setDataProvider,
+  setNamespace,
+  setServerVersion,
+  setFields
+} from '@mongodb-js/compass-aggregations';
 
-const store = initStore();
+const store = configureStore();
 
-store.refreshInput(); // Refreshes input documents.
-store.setDataProvider(error, provider); // Sets the (optional) connect error and data provider.
-store.setNamespace(ns); // Set the namespace in "db.collection" format.
-store.setServerVersion(version); // Set the lowest MongoDB server version in the cluster.
-store.setFields(fields); // Set the field names in the schema for autocompletion. See note below.
+refreshInput(store); // Refreshes input documents.
+setDataProvider(store, error, provider); // Sets the (optional) connect error and data provider.
+setNamespace(store, ns); // Set the namespace in "db.collection" format.
+setServerVersion(store, version); // Set the lowest MongoDB server version in the cluster.
+setFields(store, fields); // Set the field names in the schema for autocompletion. See note below.
 
 <Plugin store={store} />
 ```
@@ -29,9 +36,9 @@ store.setFields(fields); // Set the field names in the schema for autocompletion
 
 ```js
 const Component = appRegistry.getRole('Collection.Tab')[0].component;
-const initStore = appRegistry.getStore('Aggregations.Store');
+const configureStore = appRegistry.getStore('Aggregations.Store');
 
-<Component store={initStore} />
+<Component store={configureStore} />
 ```
 
 ### Fields

--- a/README.md
+++ b/README.md
@@ -2,6 +2,72 @@
 
 > Compass Aggregation Pipeline Builder
 
+## Usage
+
+This plugin uses an instance of a Redux store and not the traditional singleton,
+so the store instance must be passed to the plugin. The plugin exports a function
+to initialise the store instance, which decorates it with various methods to
+conveniently set any values it uses.
+
+### Browser
+
+```js
+import Plugin, { initStore } from '@mongodb-js/compass-aggregations';
+
+const store = initStore();
+
+store.refreshInput(); // Refreshes input documents.
+store.setDataProvider(error, provider); // Sets the (optional) connect error and data provider.
+store.setNamespace(ns); // Set the namespace in "db.collection" format.
+store.setServerVersion(version); // Set the lowest MongoDB server version in the cluster.
+store.setFields(fields); // Set the field names in the schema for autocompletion. See note below.
+
+<Plugin store={store} />
+```
+
+### Hadron/Electron
+
+```js
+const Component = appRegistry.getRole('Collection.Tab')[0].component;
+const initStore = appRegistry.getStore('Aggregations.Store');
+
+<Component store={initStore} />
+```
+
+### Fields
+
+The fields array must be an array of objects that the ACE editor autocompleter understands. See
+[This example](https://github.com/mongodb-js/ace-autocompleter/blob/master/lib/constants/accumulators.js)
+for what that array looks like.
+
+### Data Provider
+
+The data provider is an object that must adhere to the following interface:
+
+```js
+/**
+ * Get a count of documents.
+ *
+ * @param {String} namespace - The namespace in "db.collection" format.
+ * @param {Object} filter - The MQL query filter.
+ * @param {Object} options - The query options.
+ * @param {Function} callback - Gets error and integer count as params.
+ */
+provider.count(namespace, filter, options, callback);
+
+/**
+ * Execute an aggregation pipeline.
+ *
+ * @param {String} namespace - The namespace in "db.collection" format.
+ * @param {Array} pipeline - The pipeline.
+ * @param {Object} options - The agg options.
+ * @param {Function} callback - Gets error and cursor as params. Cursor must
+ *   implement #toArray (which takes a callback with error and an array of result docs)
+ *   and #close
+ */
+provider.aggregate(namespace, pipeline, options, callback);
+```
+
 ## License
 
 Apache 2.0

--- a/electron/renderer/index.js
+++ b/electron/renderer/index.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import app from 'hadron-app';
 import AppRegistry from 'hadron-app-registry';
 import { AppContainer } from 'react-hot-loader';
-import AggregationsPlugin, { activate, initStore } from 'plugin';
+import AggregationsPlugin, { activate, configureStore } from 'plugin';
 import FieldStore, { activate as fieldsActivate } from '@mongodb-js/compass-field-store';
 
 // Import global less file. Note: these styles WILL NOT be used in compass, as compass provides its own set
@@ -33,7 +33,7 @@ document.body.appendChild(root);
 const render = Component => {
   ReactDOM.render(
     <AppContainer>
-      <Component store={initStore()} />
+      <Component store={configureStore()} />
     </AppContainer>,
     document.getElementById('root')
   );

--- a/electron/renderer/index.js
+++ b/electron/renderer/index.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import app from 'hadron-app';
 import AppRegistry from 'hadron-app-registry';
 import { AppContainer } from 'react-hot-loader';
-import AggregationsPlugin, { activate } from 'plugin';
+import AggregationsPlugin, { activate, initStore } from 'plugin';
 import FieldStore, { activate as fieldsActivate } from '@mongodb-js/compass-field-store';
 
 // Import global less file. Note: these styles WILL NOT be used in compass, as compass provides its own set
@@ -33,7 +33,7 @@ document.body.appendChild(root);
 const render = Component => {
   ReactDOM.render(
     <AppContainer>
-      <Component />
+      <Component store={initStore()} />
     </AppContainer>,
     document.getElementById('root')
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -5925,7 +5925,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5946,12 +5947,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5966,17 +5969,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6093,7 +6099,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6105,6 +6112,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6119,6 +6127,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6126,12 +6135,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6150,6 +6161,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6230,7 +6242,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6242,6 +6255,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6327,7 +6341,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6363,6 +6378,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6382,6 +6398,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6425,12 +6442,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -11405,7 +11424,7 @@
         "mongodb": "^3.1.9",
         "mongodb-js-errors": "^0.2.1",
         "mongodb-ns": "^2.0.0",
-        "triejs": "github:rueckstiess/triejs#dd30f999a9a98420e1de8e2b2ff2e6ab742ce4a5"
+        "triejs": "github:rueckstiess/triejs"
       },
       "dependencies": {
         "ampersand-class-extend": {
@@ -12158,7 +12177,6 @@
       "integrity": "sha512-4Gg+X7ccp9ji73IaQzOoPZza02t+RFMX7cFQs9+peFjKtsD2zDlLCS9baqWX45qkMC3UOL//i8zLlUem1TPqFA==",
       "requires": {
         "bson": "^1.0.9",
-        "context-eval": "github:durran/context-eval#8900e57d1e9995f641ee601761672d1f9c5c726d",
         "debug": "^3.1.0",
         "is-json": "^2.0.1",
         "javascript-stringify": "^1.6.0",
@@ -12172,7 +12190,7 @@
       "dependencies": {
         "context-eval": {
           "version": "github:durran/context-eval#8900e57d1e9995f641ee601761672d1f9c5c726d",
-          "from": "github:durran/context-eval"
+          "from": "github:durran/context-eval#8900e57d1e9995f641ee601761672d1f9c5c726d"
         }
       }
     },
@@ -12847,6 +12865,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -14029,7 +14048,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",

--- a/src/components/aggregations/aggregations.spec.js
+++ b/src/components/aggregations/aggregations.spec.js
@@ -2,14 +2,14 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import Aggregations from 'components/aggregations';
-import store from 'stores';
+import initStore from 'stores';
 import styles from './aggregations.less';
 
 describe('Aggregations [Component]', () => {
   let component;
 
   beforeEach(() => {
-    component = mount(<Aggregations store={store} />);
+    component = mount(<Aggregations store={initStore()} />);
   });
 
   afterEach(() => {

--- a/src/components/aggregations/aggregations.spec.js
+++ b/src/components/aggregations/aggregations.spec.js
@@ -2,14 +2,14 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import Aggregations from 'components/aggregations';
-import initStore from 'stores';
+import configureStore from 'stores';
 import styles from './aggregations.less';
 
 describe('Aggregations [Component]', () => {
   let component;
 
   beforeEach(() => {
-    component = mount(<Aggregations store={initStore()} />);
+    component = mount(<Aggregations store={configureStore()} />);
   });
 
   afterEach(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import AggregationsPlugin from './plugin';
-import AggregationsStore from 'stores';
+import initStore from 'stores';
 import { Aggregations } from 'components/aggregations';
 import StageEditor from 'components/stage-editor';
 
@@ -19,7 +19,7 @@ const ROLE = {
  **/
 const activate = (appRegistry) => {
   appRegistry.registerRole('Collection.Tab', ROLE);
-  appRegistry.registerStore('Aggregations.Store', AggregationsStore);
+  appRegistry.registerStore('Aggregations.Store', initStore);
 };
 
 /**
@@ -33,4 +33,4 @@ const deactivate = (appRegistry) => {
 };
 
 export default AggregationsPlugin;
-export { activate, deactivate, Aggregations, StageEditor };
+export { activate, deactivate, Aggregations, StageEditor, initStore };

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import AggregationsPlugin from './plugin';
-import initStore from 'stores';
+import configureStore from 'stores';
 import { Aggregations } from 'components/aggregations';
 import StageEditor from 'components/stage-editor';
 
@@ -19,7 +19,7 @@ const ROLE = {
  **/
 const activate = (appRegistry) => {
   appRegistry.registerRole('Collection.Tab', ROLE);
-  appRegistry.registerStore('Aggregations.Store', initStore());
+  appRegistry.registerStore('Aggregations.Store', configureStore());
 };
 
 /**
@@ -33,4 +33,4 @@ const deactivate = (appRegistry) => {
 };
 
 export default AggregationsPlugin;
-export { activate, deactivate, Aggregations, StageEditor, initStore };
+export { activate, deactivate, Aggregations, StageEditor, configureStore };

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ const ROLE = {
  **/
 const activate = (appRegistry) => {
   appRegistry.registerRole('Collection.Tab', ROLE);
-  appRegistry.registerStore('Aggregations.Store', initStore);
+  appRegistry.registerStore('Aggregations.Store', initStore());
 };
 
 /**

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -2,7 +2,13 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Aggregations from 'components/aggregations';
 import { Provider } from 'react-redux';
-import initStore from 'stores';
+import configureStore, {
+  refreshInput,
+  setDataProvider,
+  setNamespace,
+  setServerVersion,
+  setFields
+} from 'stores';
 
 class Plugin extends Component {
   static displayName = 'AggregationsPlugin';
@@ -27,4 +33,4 @@ class Plugin extends Component {
 }
 
 export default Plugin;
-export { Plugin, initStore };
+export { Plugin, configureStore, refreshInput, setDataProvider, setNamespace, setServerVersion, setFields };

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,10 +1,16 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Aggregations from 'components/aggregations';
 import { Provider } from 'react-redux';
-import store from 'stores';
+import initStore from 'stores';
 
 class Plugin extends Component {
   static displayName = 'AggregationsPlugin';
+
+  static propTypes = {
+    store: PropTypes.object
+  }
+
 
   /**
    * Connect the Plugin to the store and render.
@@ -13,7 +19,7 @@ class Plugin extends Component {
    */
   render() {
     return (
-      <Provider store={store}>
+      <Provider store={this.props.store}>
         <Aggregations />
       </Provider>
     );
@@ -21,4 +27,4 @@ class Plugin extends Component {
 }
 
 export default Plugin;
-export { Plugin };
+export { Plugin, initStore };

--- a/src/stores/store.js
+++ b/src/stores/store.js
@@ -10,123 +10,130 @@ import { serverVersionChanged } from 'modules/server-version';
 import { appRegistryActivated } from 'modules/app-registry';
 
 /**
- * The store has a combined pipeline reducer plus the thunk middleware.
+ * Function to initialise a store for use in this plugin.
  */
-const store = createStore(reducer, applyMiddleware(thunk));
-
-/**
- * Refresh the input documents.
- */
-const refreshInput = () => {
-  store.dispatch(refreshInputDocuments());
-};
-
-/**
- * Set the data provider.
- *
- * @param {Error} error - The error (if any) while connecting.
- * @param {Object} provider - The data provider.
- */
-const setDataProvider = (error, provider) => {
-  store.dispatch(dataServiceConnected(error, provider));
-};
-
-/**
- * Set the namespace in the store.
- *
- * @param {String} ns - The namespace in "db.collection" format.
- */
-const setNamespace = (ns) => {
-  const namespace = toNS(ns);
-  if (namespace.collection) {
-    store.dispatch(namespaceChanged(ns));
-    refreshInput();
-  }
-};
-
-/**
- * Set the server version.
- *
- * @param {String} version - The version.
- */
-const setServerVersion = (version) => {
-  store.dispatch(serverVersionChanged(version));
-};
-
-/**
- * Set the fields for the autocompleter.
- *
- * @param {Array} fields - The fields array in the ACE autocompleter format.
- */
-const setFields = (fields) => {
-  store.dispatch(fieldsChanged(fields));
-};
-
-/**
- * This hook is Compass specific to listen to app registry events.
- *
- * @param {AppRegistry} appRegistry - The app registry.
- */
-store.onActivated = (appRegistry) => {
+const initStore = () => {
   /**
-   * When the collection is changed, update the store.
+   * The store has a combined pipeline reducer plus the thunk middleware.
+   */
+  const store = createStore(reducer, applyMiddleware(thunk));
+
+  /**
+   * Refresh the input documents.
+   */
+  store.refreshInput = () => {
+    store.dispatch(refreshInputDocuments());
+  };
+
+  /**
+   * Set the data provider.
    *
-   * @param {String} ns - The full namespace.
+   * @param {Error} error - The error (if any) while connecting.
+   * @param {Object} provider - The data provider.
    */
-  appRegistry.on('collection-changed', (ns) => {
-    setNamespace(ns);
-  });
+  store.setDataProvider = (error, provider) => {
+    store.dispatch(dataServiceConnected(error, provider));
+  };
 
   /**
-   * When the collection is changed, update the store.
-   */
-  appRegistry.on('import-finished', () => {
-    refreshInput();
-  });
-
-  /**
-   * Refresh documents on data refresh.
-   */
-  appRegistry.on('refresh-data', () => {
-    const ns = appRegistry.getStore('App.NamespaceStore').ns;
-    // TODO: only refresh when we are in the index tab; for now just check if
-    // we are in the documents set of tabs.
-    if (ns.indexOf('.' === 0)) refreshInput();
-  });
-
-  /**
-   * Set the data service in the store when connected.
+   * Set the namespace in the store.
    *
-   * @param {Error} error - The error.
-   * @param {DataService} dataService - The data service.
+   * @param {String} ns - The namespace in "db.collection" format.
    */
-  appRegistry.on('data-service-connected', (error, dataService) => {
-    setDataProvider(error, dataService);
-  });
+  store.setNamespace = (ns) => {
+    const namespace = toNS(ns);
+    if (namespace.collection) {
+      store.dispatch(namespaceChanged(ns));
+      store.refreshInput();
+    }
+  };
 
   /**
-   * When the schema fields change, update the state with the new
-   * fields.
-   *
-   * @param {Object} fields - The fields.
-   */
-  appRegistry.getStore('Field.Store').listen((fields) => {
-    setFields(fields.aceFields);
-  });
-
-  /**
-   * When the instance is loaded, set our server version.
+   * Set the server version.
    *
    * @param {String} version - The version.
    */
-  appRegistry.on('server-version-changed', (version) => {
-    setServerVersion(version);
-  });
+  store.setServerVersion = (version) => {
+    store.dispatch(serverVersionChanged(version));
+  };
 
   /**
-   * Set the app registry to use later.
+   * Set the fields for the autocompleter.
+   *
+   * @param {Array} fields - The fields array in the ACE autocompleter format.
    */
-  store.dispatch(appRegistryActivated(appRegistry));
+  store.setFields = (fields) => {
+    store.dispatch(fieldsChanged(fields));
+  };
+
+  /**
+   * This hook is Compass specific to listen to app registry events.
+   *
+   * @param {AppRegistry} appRegistry - The app registry.
+   */
+  store.onActivated = (appRegistry) => {
+    /**
+     * When the collection is changed, update the store.
+     *
+     * @param {String} ns - The full namespace.
+     */
+    appRegistry.on('collection-changed', (ns) => {
+      store.setNamespace(ns);
+    });
+
+    /**
+     * When the collection is changed, update the store.
+     */
+    appRegistry.on('import-finished', () => {
+      store.refreshInput();
+    });
+
+    /**
+     * Refresh documents on data refresh.
+     */
+    appRegistry.on('refresh-data', () => {
+      const ns = appRegistry.getStore('App.NamespaceStore').ns;
+      // TODO: only refresh when we are in the index tab; for now just check if
+      // we are in the documents set of tabs.
+      if (ns.indexOf('.' === 0)) store.refreshInput();
+    });
+
+    /**
+     * Set the data service in the store when connected.
+     *
+     * @param {Error} error - The error.
+     * @param {DataService} dataService - The data service.
+     */
+    appRegistry.on('data-service-connected', (error, dataService) => {
+      store.setDataProvider(error, dataService);
+    });
+
+    /**
+     * When the schema fields change, update the state with the new
+     * fields.
+     *
+     * @param {Object} fields - The fields.
+     */
+    appRegistry.getStore('Field.Store').listen((fields) => {
+      store.setFields(fields.aceFields);
+    });
+
+    /**
+     * When the instance is loaded, set our server version.
+     *
+     * @param {String} version - The version.
+     */
+    appRegistry.on('server-version-changed', (version) => {
+      store.setServerVersion(version);
+    });
+
+    /**
+     * Set the app registry to use later.
+     */
+    store.dispatch(appRegistryActivated(appRegistry));
+  };
+
+  return store;
 };
 
-export default store;
+export default initStore;

--- a/src/stores/store.spec.js
+++ b/src/stores/store.spec.js
@@ -1,6 +1,6 @@
 import AppRegistry from 'hadron-app-registry';
 import FieldStore, { activate } from '@mongodb-js/compass-field-store';
-import store from 'stores';
+import initStore from 'stores';
 import {
   stageChanged,
   stageCollapseToggled,
@@ -12,6 +12,8 @@ import {
 import { reset, INITIAL_STATE } from '../modules/index';
 
 describe('Aggregation Store', () => {
+  const store = initStore();
+
   beforeEach(() => {
     store.dispatch(reset());
   });


### PR DESCRIPTION
This PR is two fold. First, this provides hooks for Atlas to hook into when using the plugin to set all the information the plugin requires. Note this is on the created instance only and does not pollute the Store prototype.

Secondly, this changes the plugin store from a singleton to being an instance that is passed into the plugin.

This is not complete, but rather a suggestion on direction. Please feel free to comment.

Open questions:
- If we put a store config function in the app registry instead of the store, how does the `onActivated` hook get called?
- If Compass waits until the store is needed to create it, how do we initialise it? (`onActivated` is called on all stores at startup)