### PR TITLE
Split overview modules for combineReducers:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ coverage
 .lock-wscript
 .idea/
 *.swp
+*.swo
 *.iml
 .nvmrc
 .nyc_output

--- a/src/components/aggregations/aggregations.jsx
+++ b/src/components/aggregations/aggregations.jsx
@@ -17,7 +17,8 @@ import {
 
 import { exportToLanguage } from 'modules/export-to-language';
 import { openLink } from 'modules/link';
-import { deletePipeline, newPipeline, clonePipeline, toggleOverview } from 'modules';
+import { toggleOverview } from 'modules/is-overview-on';
+import { deletePipeline, newPipeline, clonePipeline } from 'modules';
 import {
   runStage,
   runOutStage,

--- a/src/components/input/input.jsx
+++ b/src/components/input/input.jsx
@@ -16,9 +16,7 @@ class Input extends PureComponent {
     isLoading: PropTypes.bool.isRequired,
     isExpanded: PropTypes.bool.isRequired,
     openLink: PropTypes.func.isRequired,
-    count: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
-    isOverviewOn: PropTypes.bool.isRequired,
-    toggleOverview: PropTypes.func.isRequired
+    count: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired
   };
 
   /**
@@ -32,8 +30,6 @@ class Input extends PureComponent {
         documents={this.props.documents}
         openLink={this.props.openLink}
         isLoading={this.props.isLoading}
-        isOverviewOn={this.props.isOverviewOn}
-        toggleOverview={this.props.toggleOverview}
       />
     ) : null;
     return (
@@ -45,8 +41,6 @@ class Input extends PureComponent {
           refreshInputDocuments={this.props.refreshInputDocuments}
           isExpanded={this.props.isExpanded}
           count={this.props.count}
-          isOverviewOn={this.props.isOverviewOn}
-          toggleOverview={this.props.toggleOverview}
         />
         {workspace}
       </div>

--- a/src/components/stage-editor/stage-editor.jsx
+++ b/src/components/stage-editor/stage-editor.jsx
@@ -49,8 +49,7 @@ class StageEditor extends Component {
     isAutoPreviewing: PropTypes.bool.isRequired,
     isValid: PropTypes.bool.isRequired,
     fromStageOperators: PropTypes.bool.isRequired,
-    setIsModified: PropTypes.func.isRequired,
-    isOverviewOn: PropTypes.bool.isRequired
+    setIsModified: PropTypes.func.isRequired
   }
 
   /**
@@ -84,8 +83,7 @@ class StageEditor extends Component {
       nextProps.index !== this.props.index ||
       nextProps.serverVersion !== this.props.serverVersion ||
       nextProps.fields.length !== this.props.fields.length ||
-      nextProps.isValid !== this.props.isValid ||
-      nextProps.isOverviewOn !== this.props.isOverviewOn;
+      nextProps.isValid !== this.props.isValid;
   }
 
   /**

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -53,8 +53,11 @@ import appRegistry, {
   appRegistryEmit,
   INITIAL_STATE as APP_REGISTRY_STATE
 } from 'modules/app-registry';
+import isOverviewOn, {
+  TOGGLE_OVERVIEW,
+  INITIAL_STATE as OVERVIEW_INITIAL_STATE
+} from 'modules/is-overview-on';
 
-const OVERVIEW_INITIAL_STATE = false;
 /**
  * The intial state of the root reducer.
  */
@@ -106,12 +109,6 @@ export const NEW_PIPELINE = 'aggregations/NEW_PIPELINE';
  */
 export const CLONE_PIPELINE = 'aggregations/CLONE_PIPELINE';
 
-
-/**
- * toggleOverview action name.
- */
-export const TOGGLE_OVERVIEW = 'aggregations/TOGGLE_OVERVIEW';
-
 /**
  * The main application reducer.
  *
@@ -139,7 +136,8 @@ const appReducer = combineReducers({
   isCollationExpanded,
   id,
   isModified,
-  importPipeline
+  importPipeline,
+  isOverviewOn
 });
 
 /**
@@ -400,10 +398,6 @@ export const newPipeline = () => ({
  */
 export const clonePipeline = () => ({
   type: CLONE_PIPELINE
-});
-
-export const toggleOverview = () => ({
-  type: TOGGLE_OVERVIEW
 });
 
 /**

--- a/src/modules/index.spec.js
+++ b/src/modules/index.spec.js
@@ -4,14 +4,13 @@ import reducer, {
   restoreSavedPipeline,
   clonePipeline,
   newPipeline,
-  toggleOverview,
   RESET,
   CLEAR_PIPELINE,
   RESTORE_PIPELINE,
   NEW_PIPELINE,
-  CLONE_PIPELINE,
-  TOGGLE_OVERVIEW
+  CLONE_PIPELINE
 } from 'modules';
+import { toggleOverview, TOGGLE_OVERVIEW } from 'modules/is-overview-on';
 
 describe('root [ module ]', () => {
   describe('#reset', () => {
@@ -147,7 +146,7 @@ describe('root [ module ]', () => {
     });
 
     describe('when the action is TOGGLE_OVERVIEW', () => {
-      describe('#isOverviewOn', () => {
+      describe('#overview', () => {
         const prevState = {
           isOverviewOn: false
         };

--- a/src/modules/is-overview-on.js
+++ b/src/modules/is-overview-on.js
@@ -1,0 +1,31 @@
+/**
+ * Toggle overview action.
+ */
+export const TOGGLE_OVERVIEW = 'aggregations/is-overview-on/TOGGLE_OVERVIEW';
+
+/**
+ * The initial state.
+ */
+export const INITIAL_STATE = false;
+
+/**
+ * This reducer only returns the initial state when combineReducers is
+ * called - otherwise the root reducer will handle the TOGGLE_OVERVIEW
+ * actions.
+ *
+ * @param {Boolean} state - The overview state.
+ *
+ * @returns {Boolean} The state.
+ */
+export default function reducer(state = INITIAL_STATE) {
+  return state;
+}
+
+/**
+ * Action creator for toggle overview events.
+ *
+ * @returns {Object} The toggle overview action.
+ */
+export const toggleOverview = () => ({
+  type: TOGGLE_OVERVIEW
+});

--- a/src/modules/is-overview-on.spec.js
+++ b/src/modules/is-overview-on.spec.js
@@ -1,0 +1,19 @@
+import reducer, { toggleOverview, TOGGLE_OVERVIEW } from 'modules/is-overview-on';
+
+describe('overview module', () => {
+  describe('#toggleOverview', () => {
+    it('returns the TOGGLE_OVERVIEW action', () => {
+      expect(toggleOverview()).to.deep.equal({
+        type: TOGGLE_OVERVIEW
+      });
+    });
+  });
+
+  describe('#reducer', () => {
+    context('when the action is not toggle overview', () => {
+      it('returns the default state', () => {
+        expect(reducer(undefined, { type: 'test' })).to.equal(false);
+      });
+    });
+  });
+});

--- a/src/stores/store.spec.js
+++ b/src/stores/store.spec.js
@@ -181,7 +181,8 @@ describe('Aggregation Store', () => {
             importPipeline: INITIAL_STATE.importPipeline,
             collation: INITIAL_STATE.collation,
             collationString: INITIAL_STATE.collationString,
-            isCollationExpanded: INITIAL_STATE.isCollationExpanded
+            isCollationExpanded: INITIAL_STATE.isCollationExpanded,
+            isOverviewOn: INITIAL_STATE.isOverviewOn
           });
         });
       });
@@ -218,7 +219,8 @@ describe('Aggregation Store', () => {
             importPipeline: INITIAL_STATE.importPipeline,
             collation: INITIAL_STATE.collation,
             collationString: INITIAL_STATE.collationString,
-            isCollationExpanded: INITIAL_STATE.isCollationExpanded
+            isCollationExpanded: INITIAL_STATE.isCollationExpanded,
+            isOverviewOn: INITIAL_STATE.isOverviewOn
           });
         });
       });


### PR DESCRIPTION
combineReducers expects that a reducer exists for each part of the state
it operates on, otherwise it console.errors that a key is in the state
that it doesn't know about. Also without a module listed in
combineReducers the initial state of the store is set up with any extra
state as undefined. This causes prop validation errors when initialising
the component as isOverviewOn is undefined at that point.

The later could be fixed by setting a default in the aggregations
component but does not solve the first annoying issue. This is an
in-between solution that allows isOverviewOn to continue handling the
toggle event in the root module, while allowing for the is-overview-on
module to hold the action creator and the reducer that sets up the
initial state.