### PR TITLE
COMPASS-3482: Save Pipeline modals

### DIFF
--- a/examples/aggregations.stories.js
+++ b/examples/aggregations.stories.js
@@ -69,6 +69,8 @@ const GROUPED_STATS_EXAMPLE = {
       previewDocuments: []
     }
   ]
+BASE_STATE.dataService.dataService = {
+  aggregate: () => {}
 };
 
 storiesOf('<Aggregations>', module)

--- a/examples/aggregations.stories.js
+++ b/examples/aggregations.stories.js
@@ -9,66 +9,13 @@ import { configureStore } from 'utils/configureStore';
 
 import BASIC_EXAMPLE from './example-basic.js';
 import COMPLEX_EXAMPLE from './example-complex.js';
+import ARRAY_STATS_EXAMPLE from './example-array-stats.js';
+import GROUPED_STATS_EXAMPLE from './example-grouped-stats.js';
 
 const BASE_STATE = {
   ...INITIAL_STATE
 };
 
-import {
-  INITIAL_INPUT_DOCUMENTS,
-  EXAMPLE,
-  STAGE_DEFAULTS
-} from './example-constants.js';
-
-// gathering stats when items are in an array using $project accumulators
-const ARRAY_STATS_EXAMPLE = {
-  ...EXAMPLE,
-  namespace: 'aggregations.icecream_data',
-  pipeline: [
-    {
-      ...STAGE_DEFAULTS,
-      id: 0,
-      stageOperator: '$project',
-      stage: `{
-  _id: 0,
-  average_cpi: {$avg: "$trends.icecream_cpi" },
-  max_cpi: {$max: "$trends.icecream_cpi" },
-  min_cpi: {$min: "$trends.icecream_cpi" },
-  cpi_deviation: {$stdDevPop: "$trends.icecream_cpi" }
-}`,
-    }
-  ]
-};
-
-// gathering metacritic info for movies that have Tom Hanks or Daniel Day-Lewis
-// as cast members
-const GROUPED_STATS_EXAMPLE = {
-  ...EXAMPLE,
-  namespace: 'aggregations.movies',
-  pipeline: [
-    {
-      ...STAGE_DEFAULTS,
-      id: 0,
-      stageOperator: '$match',
-      stage: `{
-  cast: { $in: ['Tom Hanks', 'Daniel Day-Lewis'] }
-}`,
-      previewDocuments: []
-    },
-    {
-      ...STAGE_DEFAULTS,
-      id: 1,
-      stageOperator: '$group',
-      stage: `{
-  _id: 0,
-  average_rating: { $avg: '$metacritic' },
-  films_counted: { $sum: 1 },
-  min_rating: { $min: '$metacritic' },
-  max_rating: { $max: '$metacritic' }
-}`,
-      previewDocuments: []
-    }
-  ]
 BASE_STATE.dataService.dataService = {
   aggregate: () => {}
 };
@@ -127,7 +74,7 @@ storiesOf('<Aggregations>', module)
       </Provider>
     );
   })
-  .add('Fullscreen > On', () => {
+  .add('isFullscreenOn', () => {
     const store = configureStore({
       ...BASE_STATE,
       isFullscreenOn: true
@@ -138,7 +85,7 @@ storiesOf('<Aggregations>', module)
       </Provider>
     );
   })
-  .add('Settings > Open', () => {
+  .add('settings > isExpanded', () => {
     const state = {
       ...BASE_STATE
     };

--- a/examples/example-array-stats.js
+++ b/examples/example-array-stats.js
@@ -1,0 +1,30 @@
+import {
+  EXAMPLE,
+  STAGE_DEFAULTS
+} from './example-constants.js';
+
+/**
+ * From @terakilobyte's aggregation examples from Education Team.
+ *
+ * @see https://gist.github.com/imlucas/5c92b6cfd46cba2a8bbb4a428c37c31b
+ */
+
+// gathering stats when items are in an array using $project accumulators
+const ARRAY_STATS_EXAMPLE = {
+  ...EXAMPLE,
+  namespace: 'aggregations.icecream_data',
+  pipeline: [{
+    ...STAGE_DEFAULTS,
+    id: 0,
+    stageOperator: '$project',
+    stage: `{
+  _id: 0,
+  average_cpi: {$avg: "$trends.icecream_cpi" },
+  max_cpi: {$max: "$trends.icecream_cpi" },
+  min_cpi: {$min: "$trends.icecream_cpi" },
+  cpi_deviation: {$stdDevPop: "$trends.icecream_cpi" }
+}`
+  }]
+};
+
+export default ARRAY_STATS_EXAMPLE;

--- a/examples/example-basic.js
+++ b/examples/example-basic.js
@@ -4,14 +4,17 @@
  * @see https://gist.github.com/imlucas/5c92b6cfd46cba2a8bbb4a428c37c31b
  */
 import {
-  EXAMPLE, STAGE_DEFAULTS, INITIAL_INPUT_DOCUMENTS
+  EXAMPLE,
+  STAGE_DEFAULTS,
+  INITIAL_INPUT_DOCUMENTS
 } from './example-constants';
 
 import {
   ObjectId
 } from 'bson';
 
-const SOLAR_SYSTEM_DOCUMENTS = [{
+const SOLAR_SYSTEM_DOCUMENTS = [
+  {
     _id: new ObjectId('59a06674c8df9f3cd2ee7d54'),
     name: 'Earth',
     type: 'Terrestrial planet',
@@ -454,7 +457,8 @@ const SOLAR_SYSTEM_DOCUMENTS = [{
   }
 ];
 
-const MATCHING_SOLAR_SYSTEM_DOCUMENTS = [{
+const MATCHING_SOLAR_SYSTEM_DOCUMENTS = [
+  {
     _id: new ObjectId('59a06674c8df9f3cd2ee7d54'),
     name: 'Earth',
     type: 'Terrestrial planet',
@@ -661,7 +665,8 @@ const STATE = {
     documents: SOLAR_SYSTEM_DOCUMENTS
   },
   namespace: 'aggregations.solarSystem',
-  pipeline: [{
+  pipeline: [
+    {
       ...STAGE_DEFAULTS,
       id: new ObjectId().toHexString(),
       previewDocuments: MATCHING_SOLAR_SYSTEM_DOCUMENTS,

--- a/examples/example-complex.js
+++ b/examples/example-complex.js
@@ -1,17 +1,11 @@
+import { EXAMPLE, STAGE_DEFAULTS } from './example-constants';
+import { ObjectId } from 'bson';
+
 /**
  * From @terakilobyte's aggregation examples from Education Team.
- * 
+ *
  * @see https://gist.github.com/imlucas/5c92b6cfd46cba2a8bbb4a428c37c31b
  */
-import {
-  EXAMPLE,
-  STAGE_DEFAULTS,
-  INITIAL_INPUT_DOCUMENTS
-} from './example-constants';
-
-import {
-  ObjectId
-} from 'bson';
 
 // do I have schema problems?
 // the following tells me if I have mistyped names or bad references for a lookup
@@ -19,10 +13,10 @@ const COMPLEX_EXAMPLE = {
   ...EXAMPLE,
   namespace: 'aggregations.air_alliances',
   pipeline: [{
-      ...STAGE_DEFAULTS,
-      id: new ObjectId().toHexString(),
-      stageOperator: '$lookup',
-      stage: `{
+    ...STAGE_DEFAULTS,
+    id: new ObjectId().toHexString(),
+    stageOperator: '$lookup',
+    stage: `{
   from: "air_airlines",
   let: { maybe_name: "$airlines" },
   pipeline: [
@@ -64,7 +58,6 @@ const COMPLEX_EXAMPLE = {
     }
   ],
   as: "found"
-}
 }`,
       previewDocuments: []
     },

--- a/examples/example-grouped-stats.js
+++ b/examples/example-grouped-stats.js
@@ -1,0 +1,41 @@
+import {
+  EXAMPLE,
+  STAGE_DEFAULTS
+} from './example-constants.js';
+
+/**
+ * From @terakilobyte's aggregation examples from Education Team.
+ *
+ * @see https://gist.github.com/imlucas/5c92b6cfd46cba2a8bbb4a428c37c31b
+ */
+
+// gathering metacritic info for movies that have Tom Hanks or Daniel Day-Lewis
+// as cast members
+const GROUPED_STATS_EXAMPLE = {
+  ...EXAMPLE,
+  namespace: 'aggregations.movies',
+  pipeline: [{
+    ...STAGE_DEFAULTS,
+    id: 0,
+    stageOperator: '$match',
+    stage: `{
+cast: { $in: ['Tom Hanks', 'Daniel Day-Lewis'] }
+}`,
+    previewDocuments: []
+  },
+  {
+    ...STAGE_DEFAULTS,
+    id: 1,
+    stageOperator: '$group',
+    stage: `{
+  _id: 0,
+  average_rating: { $avg: '$metacritic' },
+  films_counted: { $sum: 1 },
+  min_rating: { $min: '$metacritic' },
+  max_rating: { $max: '$metacritic' }
+}`,
+    previewDocuments: []
+  }]
+};
+
+export default GROUPED_STATS_EXAMPLE;

--- a/examples/pipeline-toolbar.stories.js
+++ b/examples/pipeline-toolbar.stories.js
@@ -18,7 +18,7 @@ const PROPS = {
 import { action } from '@storybook/addon-actions';
 
 
-storiesOf('<PipelineToolbar>', module)
+storiesOf('Styling > PipelineToolbar', module)
   .addDecorator(story => <ComponentPreview>{story()}</ComponentPreview>)
   .add('Default', () => {
 

--- a/examples/saving-pipeline-modal.stories.js
+++ b/examples/saving-pipeline-modal.stories.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { ComponentPreview } from 'storybook/decorators';
+
+// import { Provider } from 'react-redux';
+// import { INITIAL_STATE } from 'modules';
+// import { configureStore } from 'utils/configureStore';
+
+import { action } from '@storybook/addon-actions';
+
+const PROPS = {
+  isOpen: true,
+  isSaving: false,
+  name: 'Joys Pipeline',
+  savingPipelineCancel: action('savingPipelineCancel'),
+  savingPipelineApply: action('savingPipelineApply'),
+  savingPipelineNameChanged: action('savingPipelineNameChanged')
+};
+
+import SavingPipelineModal from 'components/saving-pipeline-modal';
+
+storiesOf('<SavingPipelineModal>', module)
+  .addDecorator(story => <ComponentPreview>{story()}</ComponentPreview>)
+  .add('Open+Name', () => {
+    return (
+      <SavingPipelineModal {...PROPS} />
+    );
+  });

--- a/examples/saving-pipeline-modal.stories.js
+++ b/examples/saving-pipeline-modal.stories.js
@@ -14,7 +14,8 @@ const PROPS = {
   name: 'Joys Pipeline',
   savingPipelineCancel: action('savingPipelineCancel'),
   savingPipelineApply: action('savingPipelineApply'),
-  savingPipelineNameChanged: action('savingPipelineNameChanged')
+  savingPipelineNameChanged: action('savingPipelineNameChanged'),
+  saveCurrentPipeline: action('saveCurrentPipeline')
 };
 
 import SavingPipelineModal from 'components/saving-pipeline-modal';

--- a/examples/saving-pipeline-modal.stories.js
+++ b/examples/saving-pipeline-modal.stories.js
@@ -9,9 +9,9 @@ import { ComponentPreview } from 'storybook/decorators';
 import { action } from '@storybook/addon-actions';
 
 const PROPS = {
-  isOpen: true,
-  isSaving: false,
-  name: 'Joys Pipeline',
+  isOpen: false,
+  isSaveAs: false,
+  name: '',
   savingPipelineCancel: action('savingPipelineCancel'),
   savingPipelineApply: action('savingPipelineApply'),
   savingPipelineNameChanged: action('savingPipelineNameChanged'),
@@ -22,8 +22,42 @@ import SavingPipelineModal from 'components/saving-pipeline-modal';
 
 storiesOf('<SavingPipelineModal>', module)
   .addDecorator(story => <ComponentPreview>{story()}</ComponentPreview>)
-  .add('Open+Name', () => {
+  .add('isOpen', () => {
+    const props = {
+      ...PROPS,
+      isOpen: true
+    };
     return (
-      <SavingPipelineModal {...PROPS} />
+      <SavingPipelineModal {...props} />
     );
-  });
+  })
+  .add('isOpen > name', () => {
+    const props = {
+      ...PROPS,
+      name: 'Joys Pipeline',
+      isOpen: true
+    };
+    return (
+      <SavingPipelineModal {...props} />
+    );
+  })
+  .add('isOpen > isSaveAs', () => {
+    const props = {
+      ...PROPS,
+      isOpen: true,
+      name: 'Joys Pipeline',
+      isSaveAs: true
+    };
+    return (
+      <SavingPipelineModal {...props} />
+    );
+  })
+  .add('Default', () => {
+    const props = {
+      ...PROPS
+    };
+    return (
+      <SavingPipelineModal {...props} />
+    );
+  })
+  ;

--- a/examples/saving-pipeline-modal.stories.js
+++ b/examples/saving-pipeline-modal.stories.js
@@ -20,7 +20,7 @@ const PROPS = {
 
 import SavingPipelineModal from 'components/saving-pipeline-modal';
 
-storiesOf('<SavingPipelineModal>', module)
+storiesOf('Styling > SavingPipelineModal', module)
   .addDecorator(story => <ComponentPreview>{story()}</ComponentPreview>)
   .add('isOpen', () => {
     const props = {

--- a/examples/settings.stories.js
+++ b/examples/settings.stories.js
@@ -2,38 +2,38 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { ComponentPreview } from 'storybook/decorators';
 
-import { Provider } from 'react-redux';
 import { INITIAL_STATE as _BASE_STATE } from 'modules/settings';
-
 import { INITIAL_STATE as INITIAL_LIMIT_STATE } from 'modules/limit';
 import { INITIAL_STATE as INITIAL_MAX_TIME_MS_STATE } from 'modules/max-time-ms';
 import { INITIAL_STATE as INITIAL_LARGE_LIMIT_STATE } from 'modules/large-limit';
 
-import Settings from 'components/settings';
-import { configureStore } from 'utils/configureStore';
-
 import ACTION_PROPS from './action-creators';
 
-const INITIAL_STATE = {
+import Settings from 'components/settings';
+
+const PROPS = {
   ..._BASE_STATE,
-  isExpanded: true,
+  settings: _BASE_STATE,
+  isCommenting: true,
   limit: INITIAL_LIMIT_STATE,
   largeLimit: INITIAL_LARGE_LIMIT_STATE,
-  maxTimeMS: INITIAL_MAX_TIME_MS_STATE
+  maxTimeMS: INITIAL_MAX_TIME_MS_STATE,
+  ...ACTION_PROPS
 };
 
 storiesOf('<Settings>', module)
   .addDecorator(story => <ComponentPreview>{story()}</ComponentPreview>)
-  .add('Expanded', () => {
-    const store = configureStore(INITIAL_STATE);
-    return (
-      <Provider store={store}>
-        <Settings
-          isCommenting
-          isExpanded
-          settings={INITIAL_STATE}
-          {...ACTION_PROPS}
-        />
-      </Provider>
-    );
-  });
+  .add('isExpanded', () => {
+    const props = {
+      ...PROPS,
+      isExpanded: true
+    };
+    return <Settings {...props} />;
+  })
+  .add('Default', () => {
+    const props = {
+      ...PROPS
+    };
+    return <Settings {...props} />;
+  })
+  ;

--- a/examples/settings.stories.js
+++ b/examples/settings.stories.js
@@ -21,7 +21,7 @@ const PROPS = {
   ...ACTION_PROPS
 };
 
-storiesOf('<Settings>', module)
+storiesOf('Styling > Settings', module)
   .addDecorator(story => <ComponentPreview>{story()}</ComponentPreview>)
   .add('isExpanded', () => {
     const props = {

--- a/examples/stage-editor.stories.js
+++ b/examples/stage-editor.stories.js
@@ -7,38 +7,83 @@ import { INITIAL_STATE } from 'modules';
 import { configureStore } from 'utils/configureStore';
 
 import { STAGE_DEFAULTS } from './example-constants.js';
-
 import { ObjectId } from 'bson';
+import ACTION_PROPS from './action-creators';
 
-import { action } from '@storybook/addon-actions';
-
-const BASE_STATE = {
-  ...INITIAL_STATE
-};
+import BASIC_EXAMPLE from './example-basic.js';
+import COMPLEX_EXAMPLE from './example-complex.js';
+import ARRAY_STATS_EXAMPLE from './example-array-stats.js';
+import GROUPED_STATS_EXAMPLE from './example-grouped-stats.js';
 
 const PROPS = {
   ...STAGE_DEFAULTS,
-  runStage: action('runStage'),
-  stageChanged: action('stageChanged'),
-  setIsModified: action('setIsModified'),
+  ...ACTION_PROPS,
   fromStageOperators: true,
   isAutoPreviewing: true,
   index: 0,
   serverVersion: '4.0.0',
   fields: [],
   id: new ObjectId().toHexString(),
-  stageOperator: '$project',
-  stage: `{
-  _id: 0,
-  type: "$type",
-  avg: {$avg: "$value"}
-}`
+  stageOperator: '',
+  stage: '{}'
 };
 
 import StageEditor from 'components/stage-editor';
 
 storiesOf('<StageEditor>', module)
   .addDecorator(story => <ComponentPreview>{story()}</ComponentPreview>)
+  .add('Example > $lookup', () => {
+    const store = configureStore(INITIAL_STATE);
+    const stage = COMPLEX_EXAMPLE.pipeline[0];
+    const props = {
+      ...PROPS,
+      ...stage
+    };
+    return (
+      <Provider store={store}>
+        <StageEditor {...props} />
+      </Provider>
+    );
+  })
+  .add('Example > $project', () => {
+    const store = configureStore(INITIAL_STATE);
+    const stage = ARRAY_STATS_EXAMPLE.pipeline[0];
+    const props = {
+      ...PROPS,
+      ...stage
+    };
+    return (
+      <Provider store={store}>
+        <StageEditor {...props} />
+      </Provider>
+    );
+  })
+  .add('Example > $group', () => {
+    const store = configureStore(INITIAL_STATE);
+    const stage = GROUPED_STATS_EXAMPLE.pipeline[1];
+    const props = {
+      ...PROPS,
+      ...stage
+    };
+    return (
+      <Provider store={store}>
+        <StageEditor {...props} />
+      </Provider>
+    );
+  })
+  .add('Example > $match', () => {
+    const store = configureStore(INITIAL_STATE);
+    const stage = BASIC_EXAMPLE.pipeline[0];
+    const props = {
+      ...PROPS,
+      ...stage
+    };
+    return (
+      <Provider store={store}>
+        <StageEditor {...props} />
+      </Provider>
+    );
+  })
   .add('Default', () => {
     const store = configureStore(INITIAL_STATE);
     return (

--- a/examples/stage-editor.stories.js
+++ b/examples/stage-editor.stories.js
@@ -17,18 +17,18 @@ const BASE_STATE = {
 };
 
 const PROPS = {
-    ...STAGE_DEFAULTS,
-    runStage: action('runStage'),
-    stageChanged: action('stageChanged'),
-    setIsModified: action('setIsModified'),
-    fromStageOperators: true,
-    isAutoPreviewing: true,
-    index: 0,
-    serverVersion: '4.0.0',
-    fields: [],
-    id: new ObjectId().toHexString(),
-    stageOperator: '$project',
-    stage: `{
+  ...STAGE_DEFAULTS,
+  runStage: action('runStage'),
+  stageChanged: action('stageChanged'),
+  setIsModified: action('setIsModified'),
+  fromStageOperators: true,
+  isAutoPreviewing: true,
+  index: 0,
+  serverVersion: '4.0.0',
+  fields: [],
+  id: new ObjectId().toHexString(),
+  stageOperator: '$project',
+  stage: `{
   _id: 0,
   type: "$type",
   avg: {$avg: "$value"}

--- a/examples/stage-editor.stories.js
+++ b/examples/stage-editor.stories.js
@@ -30,7 +30,7 @@ const PROPS = {
 
 import StageEditor from 'components/stage-editor';
 
-storiesOf('<StageEditor>', module)
+storiesOf('Styling > StageEditor', module)
   .addDecorator(story => <ComponentPreview>{story()}</ComponentPreview>)
   .add('Example > $lookup', () => {
     const store = configureStore(INITIAL_STATE);

--- a/src/components/aggregations/aggregations.jsx
+++ b/src/components/aggregations/aggregations.jsx
@@ -69,7 +69,8 @@ import {
 import {
   savingPipelineNameChanged,
   savingPipelineApplyName,
-  savingPipelineCancel
+  savingPipelineCancel,
+  savingPipelineOpen
 } from 'modules/saving-pipeline';
 
 import styles from './aggregations.less';
@@ -190,7 +191,8 @@ const MappedAggregations = connect(
     toggleFullscreen,
     savingPipelineNameChanged,
     savingPipelineApplyName,
-    savingPipelineCancel
+    savingPipelineCancel,
+    savingPipelineOpen
   }
 )(Aggregations);
 

--- a/src/components/aggregations/aggregations.jsx
+++ b/src/components/aggregations/aggregations.jsx
@@ -66,6 +66,12 @@ import {
   applySettings
 } from 'modules/settings';
 
+import {
+  savingPipelineNameChanged,
+  savingPipelineApplyName,
+  savingPipelineCancel
+} from 'modules/saving-pipeline';
+
 import styles from './aggregations.less';
 
 /**
@@ -120,7 +126,8 @@ const mapStateToProps = state => ({
   limit: state.limit,
   largeLimit: state.largeLimit,
   maxTimeMS: state.maxTimeMS,
-  isFullscreenOn: state.isFullscreenOn
+  isFullscreenOn: state.isFullscreenOn,
+  savingPipeline: state.savingPipeline
 });
 
 /**
@@ -180,7 +187,10 @@ const MappedAggregations = connect(
     limitChanged,
     largeLimitChanged,
     maxTimeMSChanged,
-    toggleFullscreen
+    toggleFullscreen,
+    savingPipelineNameChanged,
+    savingPipelineApplyName,
+    savingPipelineCancel
   }
 )(Aggregations);
 

--- a/src/components/aggregations/aggregations.jsx
+++ b/src/components/aggregations/aggregations.jsx
@@ -68,7 +68,7 @@ import {
 
 import {
   savingPipelineNameChanged,
-  savingPipelineApplyName,
+  savingPipelineApply,
   savingPipelineCancel,
   savingPipelineOpen
 } from 'modules/saving-pipeline';
@@ -190,7 +190,7 @@ const MappedAggregations = connect(
     maxTimeMSChanged,
     toggleFullscreen,
     savingPipelineNameChanged,
-    savingPipelineApplyName,
+    savingPipelineApply,
     savingPipelineCancel,
     savingPipelineOpen
   }

--- a/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
+++ b/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
@@ -59,6 +59,10 @@ class PipelineBuilderToolbar extends PureComponent {
     this.props.setIsModified(true);
   };
 
+  onSaveClicked = () => {
+    this.props.savingPipelineOpen();
+  };
+
   handleSavedPipelinesOpen = () => {
     this.props.getSavedPipelines();
     this.props.savedPipelinesListToggle(1);
@@ -155,9 +159,6 @@ class PipelineBuilderToolbar extends PureComponent {
               <MenuItem onClick={this.props.newPipelineFromText}>
                 New Pipeline From Text
               </MenuItem>
-              <MenuItem onClick={this.props.clonePipeline}>
-                Clone Pipeline
-              </MenuItem>
             </Dropdown.Menu>
           </Dropdown>
         </div>
@@ -179,7 +180,7 @@ class PipelineBuilderToolbar extends PureComponent {
             <Button
               className={savePipelineClassName}
               variant="primary"
-              onClick={this.props.savingPipelineOpen}>
+              onClick={this.onSaveClicked.bind(this)}>
               Save
             </Button>
 

--- a/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
+++ b/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
@@ -63,12 +63,27 @@ class PipelineBuilderToolbar extends PureComponent {
     this.props.setIsModified(true);
   };
 
+  /**
+   * Handle clicks on the `Save` button.
+   *
+   * @returns {void}
+   */
   onSaveClicked = () => {
-    this.props.savingPipelineOpen();
+    if (!this.isSavedPipeline()) {
+      this.props.savingPipelineOpen();
+      return;
+    }
+    this.props.saveCurrentPipeline();
+    this.props.setIsModified(false);
   };
 
+  /**
+   * Handle clicks on the `Save As...` MenuItem.
+   *
+   * @returns {void}
+   */
   onSaveAsClicked = () => {
-    if (this.props.name === '') {
+    if (!this.isSavedPipeline()) {
       this.onSaveClicked();
       return;
     }
@@ -83,6 +98,14 @@ class PipelineBuilderToolbar extends PureComponent {
   handleSavedPipelinesClose = () => {
     this.props.savedPipelinesListToggle(0);
   };
+
+  /**
+   * Is the current pipeline already saved?
+   * @returns {Boolean}
+   */
+  isSavedPipeline() {
+    return this.props.name !== '';
+  }
 
   modifiedText() {
     if (!this.props.isModified) {

--- a/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
+++ b/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
@@ -77,10 +77,12 @@ class PipelineBuilderToolbar extends PureComponent {
       [styles['is-modified']]: true,
       [styles['is-modified-on']]: this.props.isModified
     });
-
+    if (!this.props.isModified) {
+      return null;
+    }
     return (
       <div className={isModifiedClassName}>
-        <span>Modified</span>
+        - <span>Modified</span>
       </div>
     );
   }
@@ -99,7 +101,8 @@ class PipelineBuilderToolbar extends PureComponent {
       btn: true,
       'btn-xs': true,
       'btn-default': !this.props.isModified || this.props.name.trim() === '',
-      'btn-primary': this.props.isModified && this.props.name.trim() !== '',
+      // 'btn-primary': this.props.isModified && this.props.name.trim() !== '',
+      'btn-primary': true,
       [styles['pipeline-builder-toolbar-save-pipeline-button']]: true
     });
     const inputClassName = classnames({
@@ -123,6 +126,31 @@ class PipelineBuilderToolbar extends PureComponent {
           iconClassName="fa fa-folder-open-o"
           clickHandler={clickHandler}
         />
+        <div>
+          <Dropdown pullRight as={ButtonGroup} id="new-pipeline-actions">
+            <Button
+              className="btn btn-xs btn-default"
+              variant="success"
+              onClick={this.props.saveCurrentPipeline}>
+              <i className="fa fa-plus-circle" />
+            </Button>
+
+            <Dropdown.Toggle
+              className="btn-default btn-xs btn"
+              split="true"
+              variant="primary"
+              id="save-pipeline-split"
+            />
+            <Dropdown.Menu>
+              <MenuItem onClick={this.props.newPipelineFromText}>
+                New Pipeline From Text
+              </MenuItem>
+              <MenuItem onClick={this.props.clonePipeline}>
+                Clone Pipeline
+              </MenuItem>
+            </Dropdown.Menu> 
+          </Dropdown>
+        </div>
         <CollationCollapser
           isCollationExpanded={this.props.isCollationExpanded}
           collationCollapseToggled={this.props.collationCollapseToggled}
@@ -131,45 +159,34 @@ class PipelineBuilderToolbar extends PureComponent {
           className={classnames(
             styles['pipeline-builder-toolbar-add-wrapper']
           )}>
-          <span>{this.props.name || 'Untitled'}</span>
-          -
+          <div className={styles['pipeline-builder-toolbar-name']}>
+            {this.props.name || 'Untitled'}
+          </div>
           {this.renderIsModifiedIndicator()}
-          {/* <input
-            placeholder="Enter a pipeline name..."
-            onChange={this.onNameChange}
-            className={inputClassName}
-            type="text"
-            value={this.props.name}
-          /> */}
         </div>
+        <div>
+          <Dropdown pullRight as={ButtonGroup} id="save-pipeline-actions">
+            <Button
+              className={savePipelineClassName}
+              variant="primary"
+              onClick={this.props.saveCurrentPipeline}>
+              Save
+            </Button>
 
-        <Dropdown pullRight as={ButtonGroup}>
-          <Button
-            className={savePipelineClassName}
-            variant="success"
-            onClick={this.props.saveCurrentPipeline}
-            // disabled={this.props.name.trim() === '' || !this.props.isModified}
-            >
-            Save
-          </Button>
+            <Dropdown.Toggle
+              className="btn-primary btn-xs btn"
+              split="true"
+              variant="success"
+              id="dropdown-split-basic"
+            />
 
-          <Dropdown.Toggle
-            className="btn-primary btn-xs"
-            split
-            variant="success"
-            id="dropdown-split-basic"
-          />
-
-          <Dropdown.Menu>
-            <MenuItem onClick={this.props.clonePipeline}>
-              Clone Pipeline
-            </MenuItem>
-            <MenuItem onClick={this.props.newPipeline}>New Pipeline</MenuItem>
-            <MenuItem onClick={this.props.newPipelineFromText}>
-              New Pipeline From Text
-            </MenuItem>
-          </Dropdown.Menu>
-        </Dropdown>
+            <Dropdown.Menu>
+              <MenuItem onClick={this.props.clonePipeline}>
+                Save pipeline as
+              </MenuItem>
+            </Dropdown.Menu>
+          </Dropdown>
+        </div>
         <div
           className={styles['pipeline-builder-toolbar-export-to-language']}
           data-tip={TOOLTIP_EXPORT_TO_LANGUAGE}

--- a/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
+++ b/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
@@ -7,7 +7,11 @@ import { Dropdown, MenuItem, Button } from 'react-bootstrap';
 import OverviewToggler from './overview-toggler';
 import CollationCollapser from './collation-collapser';
 
-import { TOOLTIP_EXPORT_TO_LANGUAGE } from '../../constants';
+import {
+  TOOLTIP_EXPORT_TO_LANGUAGE,
+  TOOLTIP_CREATE_NEW_PIPELINE,
+  TOOLTIP_OPEN_SAVED_PIPELINES
+} from '../../constants';
 
 import styles from './pipeline-builder-toolbar.less';
 
@@ -98,8 +102,6 @@ class PipelineBuilderToolbar extends PureComponent {
     const savePipelineClassName = classnames({
       btn: true,
       'btn-xs': true,
-      'btn-default': !this.props.isModified || this.props.name.trim() === '',
-      // 'btn-primary': this.props.isModified && this.props.name.trim() !== '',
       'btn-primary': true,
       [styles['pipeline-builder-toolbar-save-pipeline-button']]: true
     });
@@ -110,29 +112,42 @@ class PipelineBuilderToolbar extends PureComponent {
           isOverviewOn={this.props.isOverviewOn}
           toggleOverview={this.props.toggleOverview}
         />
-        <IconButton
-          title="Toggle Saved Pipelines"
-          className={classnames(
-            'btn',
-            'btn-xs',
-            'btn-default',
-            styles['pipeline-builder-toolbar-open-saved-pipelines-button']
-          )}
-          iconClassName="fa fa-folder-open-o"
-          clickHandler={clickHandler}
-        />
+        <span
+          data-tip={TOOLTIP_OPEN_SAVED_PIPELINES}
+          data-for="open-saved-pipelines"
+          data-place="top"
+          data-html="true">
+          <IconButton
+            title="Toggle Saved Pipelines"
+            className={classnames(
+              'btn',
+              'btn-xs',
+              'btn-default',
+              styles['pipeline-builder-toolbar-open-saved-pipelines-button']
+            )}
+            iconClassName="fa fa-folder-open-o"
+            clickHandler={clickHandler}
+          />
+          <Tooltip id="open-saved-pipelines" />
+        </span>
         <div>
           <Dropdown id="new-pipeline-actions" className="btn-group">
-            <Button
-              variant="default"
-              className={classnames(
-                'btn-xs',
-                styles['pipeline-builder-toolbar-new-button']
-              )}
-              onClick={this.props.newPipeline}>
-              <i className="fa fa-plus-circle" />
-            </Button>
-
+            <span
+              data-tip={TOOLTIP_CREATE_NEW_PIPELINE}
+              data-for="create-new-pipeline"
+              data-place="top"
+              data-html="true">
+              <Button
+                variant="default"
+                className={classnames(
+                  'btn-xs',
+                  styles['pipeline-builder-toolbar-new-button']
+                )}
+                onClick={this.props.newPipeline}>
+                <i className="fa fa-plus-circle" />
+              </Button>
+            </span>
+            <Tooltip id="create-new-pipeline" />
             <Dropdown.Toggle className="btn-default btn-xs btn" />
 
             <Dropdown.Menu>

--- a/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
+++ b/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
@@ -41,11 +41,15 @@ class PipelineBuilderToolbar extends PureComponent {
 
     /**
      * Saved Pipelines
+     *
+     * TODO (@imlucas) To make this clearer for future travellers:
+     * - Rename `savedPipeline` to `savedPipelineList`
+     * - Rename `savingPipeline*` to `savePipeline`
      */
-    savedPipeline: PropTypes.object.isRequired, // TODO List of saved-pipelines.
+    savedPipeline: PropTypes.object.isRequired,
     savedPipelinesListToggle: PropTypes.func.isRequired,
     getSavedPipelines: PropTypes.func.isRequired,
-    saveCurrentPipeline: PropTypes.func.isRequired, // TODO this goes away
+    saveCurrentPipeline: PropTypes.func.isRequired,
     savingPipelineOpen: PropTypes.func.isRequired
   };
 
@@ -54,13 +58,21 @@ class PipelineBuilderToolbar extends PureComponent {
    *
    * @param {Object} evt
    */
-  onNameChange = evt => {
+  onNameChange = (evt) => {
     this.props.nameChanged(evt.target.value);
     this.props.setIsModified(true);
   };
 
   onSaveClicked = () => {
     this.props.savingPipelineOpen();
+  };
+
+  onSaveAsClicked = () => {
+    if (this.props.name === '') {
+      this.onSaveClicked();
+      return;
+    }
+    this.props.savingPipelineOpen({ name: this.props.name, isSaveAs: true });
   };
 
   handleSavedPipelinesOpen = () => {
@@ -187,7 +199,7 @@ class PipelineBuilderToolbar extends PureComponent {
             <Dropdown.Toggle className="btn-xs btn btn-primary" />
 
             <Dropdown.Menu>
-              <MenuItem onClick={this.props.clonePipeline}>
+              <MenuItem onClick={this.onSaveAsClicked.bind(this)}>
                 Save pipeline as&hellip;
               </MenuItem>
             </Dropdown.Menu>

--- a/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
+++ b/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
@@ -127,20 +127,19 @@ class PipelineBuilderToolbar extends PureComponent {
           clickHandler={clickHandler}
         />
         <div>
-          <Dropdown pullRight as={ButtonGroup} id="new-pipeline-actions">
+          <Dropdown id="new-pipeline-actions" className="btn-group">
             <Button
-              className="btn btn-xs btn-default"
-              variant="success"
-              onClick={this.props.saveCurrentPipeline}>
+              variant="default"
+              className={classnames(
+                'btn-xs',
+                styles['pipeline-builder-toolbar-new-button']
+              )}
+              onClick={this.props.newPipeline}>
               <i className="fa fa-plus-circle" />
             </Button>
 
-            <Dropdown.Toggle
-              className="btn-default btn-xs btn"
-              split="true"
-              variant="primary"
-              id="save-pipeline-split"
-            />
+            <Dropdown.Toggle className="btn-default btn-xs btn" />
+            
             <Dropdown.Menu>
               <MenuItem onClick={this.props.newPipelineFromText}>
                 New Pipeline From Text
@@ -148,7 +147,7 @@ class PipelineBuilderToolbar extends PureComponent {
               <MenuItem onClick={this.props.clonePipeline}>
                 Clone Pipeline
               </MenuItem>
-            </Dropdown.Menu> 
+            </Dropdown.Menu>
           </Dropdown>
         </div>
         <CollationCollapser
@@ -165,7 +164,7 @@ class PipelineBuilderToolbar extends PureComponent {
           {this.renderIsModifiedIndicator()}
         </div>
         <div>
-          <Dropdown pullRight as={ButtonGroup} id="save-pipeline-actions">
+          <Dropdown id="save-pipeline-actions">
             <Button
               className={savePipelineClassName}
               variant="primary"
@@ -173,12 +172,7 @@ class PipelineBuilderToolbar extends PureComponent {
               Save
             </Button>
 
-            <Dropdown.Toggle
-              className="btn-primary btn-xs btn"
-              split="true"
-              variant="success"
-              id="dropdown-split-basic"
-            />
+            <Dropdown.Toggle className="btn-xs btn btn-primary" />
 
             <Dropdown.Menu>
               <MenuItem onClick={this.props.clonePipeline}>

--- a/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
+++ b/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
@@ -1,9 +1,9 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { TextButton, IconButton } from 'hadron-react-buttons';
+import { IconButton } from 'hadron-react-buttons';
 import { Tooltip } from 'hadron-react-components';
-import { Dropdown, MenuItem, ButtonGroup, Button } from 'react-bootstrap';
+import { Dropdown, MenuItem, Button } from 'react-bootstrap';
 import OverviewToggler from './overview-toggler';
 import CollationCollapser from './collation-collapser';
 
@@ -34,8 +34,6 @@ class PipelineBuilderToolbar extends PureComponent {
 
     isOverviewOn: PropTypes.bool.isRequired,
     toggleOverview: PropTypes.func.isRequired,
-
-    isModified: PropTypes.bool.isRequired,
 
     /**
      * Saved Pipelines
@@ -105,9 +103,6 @@ class PipelineBuilderToolbar extends PureComponent {
       'btn-primary': true,
       [styles['pipeline-builder-toolbar-save-pipeline-button']]: true
     });
-    const inputClassName = classnames({
-      [styles['pipeline-builder-toolbar-name']]: true
-    });
 
     return (
       <div className={classnames(styles['pipeline-builder-toolbar'])}>
@@ -139,7 +134,7 @@ class PipelineBuilderToolbar extends PureComponent {
             </Button>
 
             <Dropdown.Toggle className="btn-default btn-xs btn" />
-            
+
             <Dropdown.Menu>
               <MenuItem onClick={this.props.newPipelineFromText}>
                 New Pipeline From Text

--- a/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
+++ b/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
@@ -45,7 +45,8 @@ class PipelineBuilderToolbar extends PureComponent {
     savedPipeline: PropTypes.object.isRequired, // TODO List of saved-pipelines.
     savedPipelinesListToggle: PropTypes.func.isRequired,
     getSavedPipelines: PropTypes.func.isRequired,
-    saveCurrentPipeline: PropTypes.func.isRequired
+    saveCurrentPipeline: PropTypes.func.isRequired, // TODO this goes away
+    savingPipelineOpen: PropTypes.func.isRequired
   };
 
   /**
@@ -178,7 +179,7 @@ class PipelineBuilderToolbar extends PureComponent {
             <Button
               className={savePipelineClassName}
               variant="primary"
-              onClick={this.props.saveCurrentPipeline}>
+              onClick={this.props.savingPipelineOpen}>
               Save
             </Button>
 
@@ -186,7 +187,7 @@ class PipelineBuilderToolbar extends PureComponent {
 
             <Dropdown.Menu>
               <MenuItem onClick={this.props.clonePipeline}>
-                Save pipeline as
+                Save pipeline as&hellip;
               </MenuItem>
             </Dropdown.Menu>
           </Dropdown>

--- a/src/components/pipeline-toolbar/pipeline-builder-toolbar.less
+++ b/src/components/pipeline-toolbar/pipeline-builder-toolbar.less
@@ -59,12 +59,20 @@
     white-space: nowrap;
     border-radius: 3px 0px 0px 3px;
     border-right: 0;
+
+    &:hover {
+      border-right: 0;
+    }
   }
 
   &-save-pipeline-button {
     white-space: nowrap;
     border-radius: 3px 0px 0px 3px;
     border-right: 0;
+
+    &:hover+button {
+      border-left: 0;
+    }
   }
 
   &-export-to-language {

--- a/src/components/pipeline-toolbar/pipeline-builder-toolbar.less
+++ b/src/components/pipeline-toolbar/pipeline-builder-toolbar.less
@@ -52,16 +52,19 @@
 
   &-open-saved-pipelines-button {
     margin-right: 3px;
+    white-space: nowrap;
   }
 
   &-new-button {
     white-space: nowrap;
     border-radius: 3px 0px 0px 3px;
+    border-right: 0;
   }
 
   &-save-pipeline-button {
     white-space: nowrap;
     border-radius: 3px 0px 0px 3px;
+    border-right: 0;
   }
 
   &-export-to-language {

--- a/src/components/pipeline-toolbar/pipeline-builder-toolbar.less
+++ b/src/components/pipeline-toolbar/pipeline-builder-toolbar.less
@@ -33,7 +33,6 @@
   }
 
   &-add-wrapper {
-    flex-grow: 4;
     margin: 0px 3px 0px 3px;
     margin-right: 3px;
     background-color: rgba(70, 76, 79, 0.1);
@@ -41,22 +40,23 @@
     display: flex;
     border-radius: 3px;
     font-size: 12px;
-    padding: 3px;
+    padding: 2px 6px 2px 6px;
 
   }
 
   &-name {
-    height: 22px;
     font-size: 12px;
     font-weight: bold;
-    padding: 0px 5px 0px 5px;
-    border: 1px @gray5 solid;
-    border-radius: 4px;
     white-space: nowrap;
   }
 
   &-open-saved-pipelines-button {
     margin-right: 3px;
+  }
+
+  &-new-button {
+    white-space: nowrap;
+    border-radius: 3px 0px 0px 3px;
   }
 
   &-save-pipeline-button {
@@ -70,6 +70,7 @@
 }
 
 .is-modified {
+  padding-top: 1px;
   font-style: italic;
 }
 

--- a/src/components/pipeline-toolbar/pipeline-toolbar.jsx
+++ b/src/components/pipeline-toolbar/pipeline-toolbar.jsx
@@ -37,7 +37,9 @@ class PipelineToolbar extends PureComponent {
     toggleOverview: PropTypes.func.isRequired,
     toggleSettingsIsExpanded: PropTypes.func.isRequired,
     isFullscreenOn: PropTypes.bool.isRequired,
-    toggleFullscreen: PropTypes.func.isRequired
+    toggleFullscreen: PropTypes.func.isRequired,
+    savingPipeline: PropTypes.object.isRequired,
+    savingPipelineOpen: PropTypes.func.isRequired
   };
 
   static defaultProps = {
@@ -75,6 +77,8 @@ class PipelineToolbar extends PureComponent {
           isCollationExpanded={this.props.isCollationExpanded}
           isOverviewOn={this.props.isOverviewOn}
           toggleOverview={this.props.toggleOverview}
+          savingPipeline={this.props.savingPipeline}
+          savingPipelineOpen={this.props.savingPipelineOpen}
         />
         <PipelinePreviewToolbar
           toggleComments={this.props.toggleComments}

--- a/src/components/pipeline-toolbar/pipeline-toolbar.jsx
+++ b/src/components/pipeline-toolbar/pipeline-toolbar.jsx
@@ -38,7 +38,6 @@ class PipelineToolbar extends PureComponent {
     toggleSettingsIsExpanded: PropTypes.func.isRequired,
     isFullscreenOn: PropTypes.bool.isRequired,
     toggleFullscreen: PropTypes.func.isRequired,
-    savingPipeline: PropTypes.object.isRequired,
     savingPipelineOpen: PropTypes.func.isRequired
   };
 
@@ -77,7 +76,6 @@ class PipelineToolbar extends PureComponent {
           isCollationExpanded={this.props.isCollationExpanded}
           isOverviewOn={this.props.isOverviewOn}
           toggleOverview={this.props.toggleOverview}
-          savingPipeline={this.props.savingPipeline}
           savingPipelineOpen={this.props.savingPipelineOpen}
         />
         <PipelinePreviewToolbar

--- a/src/components/pipeline/pipeline.jsx
+++ b/src/components/pipeline/pipeline.jsx
@@ -13,7 +13,7 @@ import Settings from 'components/settings';
 import RestorePipelineModal from './modals/restore-pipeline-modal';
 import ImportPipeline from './modals/import-pipeline';
 import ConfirmImportPipeline from './modals/confirm-import-pipeline';
-
+import SavingPipelineModal from 'components/saving-pipeline-modal';
 import styles from './pipeline.less';
 
 /**
@@ -86,7 +86,12 @@ class Pipeline extends PureComponent {
     maxTimeMS: PropTypes.number.isRequired,
     applySettings: PropTypes.func.isRequired,
     isFullscreenOn: PropTypes.bool.isRequired,
-    toggleFullscreen: PropTypes.func.isRequired
+    toggleFullscreen: PropTypes.func.isRequired,
+    savingPipelineNameChanged: PropTypes.func.isRequired,
+    savingPipelineApply: PropTypes.func.isRequired,
+    savingPipelineCancel: PropTypes.func.isRequired,
+    savingPipelineOpen: PropTypes.func.isRequired,
+    savingPipeline: PropTypes.object.isRequired
   };
 
   /**
@@ -170,6 +175,17 @@ class Pipeline extends PureComponent {
       />
     );
 
+    const savingPipelineModal = (
+      <SavingPipelineModal
+        name={this.props.savingPipeline.name}
+        isOpen={this.props.savingPipeline.isOpen}
+        savingPipelineNameChanged={this.props.savingPipelineNameChanged}
+        savingPipelineApply={this.props.savingPipelineApply}
+        savingPipelineCancel={this.props.savingPipelineCancel}
+        savingPipelineOpen={this.props.savingPipelineOpen}
+      />
+    );
+
     return (
       <div
         className={classnames(
@@ -232,6 +248,7 @@ class Pipeline extends PureComponent {
         {this.renderRestoreModal()}
         {importPipelineModal}
         {confirmImportPipelineModal}
+        {savingPipelineModal}
       </div>
     );
   }

--- a/src/components/pipeline/pipeline.jsx
+++ b/src/components/pipeline/pipeline.jsx
@@ -179,6 +179,7 @@ class Pipeline extends PureComponent {
       <SavingPipelineModal
         name={this.props.savingPipeline.name}
         isOpen={this.props.savingPipeline.isOpen}
+        saveCurrentPipeline={this.props.saveCurrentPipeline}
         savingPipelineNameChanged={this.props.savingPipelineNameChanged}
         savingPipelineApply={this.props.savingPipelineApply}
         savingPipelineCancel={this.props.savingPipelineCancel}
@@ -218,6 +219,7 @@ class Pipeline extends PureComponent {
           toggleSettingsIsExpanded={this.props.toggleSettingsIsExpanded}
           isFullscreenOn={this.props.isFullscreenOn}
           toggleFullscreen={this.props.toggleFullscreen}
+          savingPipelineOpen={this.props.savingPipelineOpen}
         />
         {this.renderCollationToolbar()}
         {this.renderSeparator()}

--- a/src/components/pipeline/pipeline.jsx
+++ b/src/components/pipeline/pipeline.jsx
@@ -185,6 +185,7 @@ class Pipeline extends PureComponent {
         savingPipelineApply={this.props.savingPipelineApply}
         savingPipelineCancel={this.props.savingPipelineCancel}
         savingPipelineOpen={this.props.savingPipelineOpen}
+        clonePipeline={this.props.clonePipeline}
       />
     );
 

--- a/src/components/pipeline/pipeline.jsx
+++ b/src/components/pipeline/pipeline.jsx
@@ -179,6 +179,7 @@ class Pipeline extends PureComponent {
       <SavingPipelineModal
         name={this.props.savingPipeline.name}
         isOpen={this.props.savingPipeline.isOpen}
+        isSaveAs={this.props.savingPipeline.isSaveAs}
         saveCurrentPipeline={this.props.saveCurrentPipeline}
         savingPipelineNameChanged={this.props.savingPipelineNameChanged}
         savingPipelineApply={this.props.savingPipelineApply}

--- a/src/components/pipeline/pipeline.less
+++ b/src/components/pipeline/pipeline.less
@@ -14,7 +14,7 @@
     border-right: 2px solid rgba(0, 0, 0, 0.1);
     box-shadow: 1px 0px 2px rgba(0, 0, 0, 0.1);
     height: 100%;
-    z-index: 500;
+    z-index: 1;
   }
 
   &-expanded-separator {
@@ -24,7 +24,7 @@
     border-right: 2px solid rgba(0, 0, 0, 0.1);
     box-shadow: 1px 0px 2px rgba(0, 0, 0, 0.1);
     height: 100%;
-    z-index: 500;
+    z-index: 1;
   }
 
   &-fullscreen {

--- a/src/components/saving-pipeline-modal/index.js
+++ b/src/components/saving-pipeline-modal/index.js
@@ -1,0 +1,2 @@
+import SavingPipelineModal from './saving-pipeline-modal';
+export default SavingPipelineModal;

--- a/src/components/saving-pipeline-modal/saving-pipeline-modal.jsx
+++ b/src/components/saving-pipeline-modal/saving-pipeline-modal.jsx
@@ -19,7 +19,8 @@ class SavingPipelineModal extends PureComponent {
     savingPipelineCancel: PropTypes.func.isRequired,
     savingPipelineApply: PropTypes.func.isRequired,
     savingPipelineNameChanged: PropTypes.func.isRequired,
-    saveCurrentPipeline: PropTypes.func.isRequired
+    saveCurrentPipeline: PropTypes.func.isRequired,
+    clonePipeline: PropTypes.func.isRequired
   };
 
   /**
@@ -46,9 +47,15 @@ class SavingPipelineModal extends PureComponent {
 
   /**
    * Calls back to action handlers for changing the name and saving it.
+   *
+   * If canceling from `Save As...`, the current pipeline is not cloned.
    * @returns {void}
    */
   save() {
+    if (this.props.isSaveAs) {
+      this.props.clonePipeline();
+    }
+
     this.props.savingPipelineApply();
     this.props.saveCurrentPipeline();
   }
@@ -75,6 +82,7 @@ class SavingPipelineModal extends PureComponent {
               value={this.props.name}
               onChange={this.onNameChanged.bind(this)}
               className="form-control input-lg"
+              placeholder="Untitled"
             />
           </form>
         </Modal.Body>

--- a/src/components/saving-pipeline-modal/saving-pipeline-modal.jsx
+++ b/src/components/saving-pipeline-modal/saving-pipeline-modal.jsx
@@ -14,7 +14,7 @@ class SavingPipelineModal extends PureComponent {
 
   static propTypes = {
     isOpen: PropTypes.bool.isRequired,
-    isSaving: PropTypes.bool.isRequired,
+    isSaving: PropTypes.bool, // TODO Future may have a spinner or something.
     name: PropTypes.string.isRequired,
     savingPipelineCancel: PropTypes.func.isRequired,
     savingPipelineApply: PropTypes.func.isRequired,

--- a/src/components/saving-pipeline-modal/saving-pipeline-modal.jsx
+++ b/src/components/saving-pipeline-modal/saving-pipeline-modal.jsx
@@ -14,7 +14,7 @@ class SavingPipelineModal extends PureComponent {
 
   static propTypes = {
     isOpen: PropTypes.bool.isRequired,
-    isSaving: PropTypes.bool, // TODO Future may have a spinner or something.
+    isSaveAs: PropTypes.bool.isRequired,
     name: PropTypes.string.isRequired,
     savingPipelineCancel: PropTypes.func.isRequired,
     savingPipelineApply: PropTypes.func.isRequired,
@@ -59,13 +59,14 @@ class SavingPipelineModal extends PureComponent {
    * @returns {React.Component} The component.
    */
   render() {
+    const title = this.props.isSaveAs ? 'Save Pipeline As...' : 'Save Pipeline';
     return (
       <Modal
         className={styles['saving-pipeline-modal']}
         show={this.props.isOpen}
         onHide={this.props.savingPipelineCancel}>
         <Modal.Header closeButton>
-          <h4>Save Pipeline</h4>
+          <h4>{title}</h4>
         </Modal.Header>
         <Modal.Body>
           <form onSubmit={this.onSubmit.bind(this)}>
@@ -87,7 +88,7 @@ class SavingPipelineModal extends PureComponent {
           <TextButton
             id="apply-saving-pipeline"
             className="btn btn-primary btn-sm"
-            text="Create New"
+            text="Save"
             disabled={this.props.name === ''}
             clickHandler={this.save.bind(this)}
           />

--- a/src/components/saving-pipeline-modal/saving-pipeline-modal.jsx
+++ b/src/components/saving-pipeline-modal/saving-pipeline-modal.jsx
@@ -1,0 +1,82 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+// import classnames from 'classnames';
+import { Modal } from 'react-bootstrap';
+import { TextButton } from 'hadron-react-buttons';
+
+import styles from './saving-pipeline-modal.less';
+
+/**
+ * Saving pipeline modal.
+ */
+class SavingPipelineModal extends PureComponent {
+  static displayName = 'SavingPipelineModalComponent';
+
+  static propTypes = {
+    isOpen: PropTypes.bool.isRequired,
+    isSaving: PropTypes.bool.isRequired,
+    name: PropTypes.string.isRequired,
+    savingPipelineCancel: PropTypes.func.isRequired,
+    savingPipelineApply: PropTypes.func.isRequired,
+    savingPipelineNameChanged: PropTypes.func.isRequired
+  };
+
+  static defaultProps = {
+    isOpen: false,
+    isSaving: false,
+    name: ''
+  };
+
+  /**
+   * Handle the value of the input being changed.
+   *
+   * @param {Event} evt
+   * @returns {ConstrainVideoFacingModeParameters}
+   */
+  onNameChanged(evt) {
+    this.props.savingPipelineNameChanged(evt.currentTarget.value);
+  }
+
+  /**
+   * Render the component.
+   *
+   * @returns {React.Component} The component.
+   */
+  render() {
+    return (
+      <Modal
+        className={styles['saving-pipeline-modal']}
+        show={this.props.isOpen}
+        onHide={this.props.savingPipelineCancel}>
+        <Modal.Header closeButton>
+          <h4>Save Pipeline</h4>
+        </Modal.Header>
+        <Modal.Body>
+          <input
+            type="text"
+            value={this.props.name}
+            onChange={this.onNameChanged.bind(this)}
+            className="form-control input-lg"
+          />
+        </Modal.Body>
+        <Modal.Footer>
+          <TextButton
+            id="cancel-saving-pipeline"
+            className="btn btn-default btn-sm"
+            text="Cancel"
+            clickHandler={this.props.savingPipelineCancel}
+          />
+          <TextButton
+            id="apply-saving-pipeline"
+            className="btn btn-primary btn-sm"
+            text="Create New"
+            disabled={this.props.name === ''}
+            clickHandler={this.props.savingPipelineApply}
+          />
+        </Modal.Footer>
+      </Modal>
+    );
+  }
+}
+
+export default SavingPipelineModal;

--- a/src/components/saving-pipeline-modal/saving-pipeline-modal.jsx
+++ b/src/components/saving-pipeline-modal/saving-pipeline-modal.jsx
@@ -18,23 +18,39 @@ class SavingPipelineModal extends PureComponent {
     name: PropTypes.string.isRequired,
     savingPipelineCancel: PropTypes.func.isRequired,
     savingPipelineApply: PropTypes.func.isRequired,
-    savingPipelineNameChanged: PropTypes.func.isRequired
-  };
-
-  static defaultProps = {
-    isOpen: false,
-    isSaving: false,
-    name: ''
+    savingPipelineNameChanged: PropTypes.func.isRequired,
+    saveCurrentPipeline: PropTypes.func.isRequired
   };
 
   /**
    * Handle the value of the input being changed.
    *
    * @param {Event} evt
-   * @returns {ConstrainVideoFacingModeParameters}
+   * @returns {void}
    */
   onNameChanged(evt) {
     this.props.savingPipelineNameChanged(evt.currentTarget.value);
+  }
+
+  /**
+   * Handle the form submission for `Hit Enter` to save.
+   *
+   * @param {Event} evt
+   * @returns {void}
+   */
+  onSubmit(evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
+    this.save();
+  }
+
+  /**
+   * Calls back to action handlers for changing the name and saving it.
+   * @returns {void}
+   */
+  save() {
+    this.props.savingPipelineApply();
+    this.props.saveCurrentPipeline();
   }
 
   /**
@@ -52,12 +68,14 @@ class SavingPipelineModal extends PureComponent {
           <h4>Save Pipeline</h4>
         </Modal.Header>
         <Modal.Body>
-          <input
-            type="text"
-            value={this.props.name}
-            onChange={this.onNameChanged.bind(this)}
-            className="form-control input-lg"
-          />
+          <form onSubmit={this.onSubmit.bind(this)}>
+            <input
+              type="text"
+              value={this.props.name}
+              onChange={this.onNameChanged.bind(this)}
+              className="form-control input-lg"
+            />
+          </form>
         </Modal.Body>
         <Modal.Footer>
           <TextButton
@@ -71,7 +89,7 @@ class SavingPipelineModal extends PureComponent {
             className="btn btn-primary btn-sm"
             text="Create New"
             disabled={this.props.name === ''}
-            clickHandler={this.props.savingPipelineApply}
+            clickHandler={this.save.bind(this)}
           />
         </Modal.Footer>
       </Modal>

--- a/src/components/saving-pipeline-modal/saving-pipeline-modal.less
+++ b/src/components/saving-pipeline-modal/saving-pipeline-modal.less
@@ -1,5 +1,7 @@
 @import (reference) "~less/compass/_theme.less";
 
 .saving-pipeline-modal {
-
+  input {
+    font-size: 16px;
+  }
 }

--- a/src/components/saving-pipeline-modal/saving-pipeline-modal.less
+++ b/src/components/saving-pipeline-modal/saving-pipeline-modal.less
@@ -1,0 +1,5 @@
+@import (reference) "~less/compass/_theme.less";
+
+.saving-pipeline-modal {
+
+}

--- a/src/components/saving-pipeline-modal/saving-pipeline-modal.spec.js
+++ b/src/components/saving-pipeline-modal/saving-pipeline-modal.spec.js
@@ -8,15 +8,11 @@ import styles from './saving-pipeline-modal.less';
 describe('SavingPipelineModal [Component]', () => {
   context('when the component is rendered', () => {
     let component;
-    const savingPipeline = {
-      isOpen: true,
-      name: '',
-      isSaving: false
-    };
 
     const savingPipelineNameChangedSpy = sinon.spy();
     const savingPipelineApplySpy = sinon.spy();
     const savingPipelineCancelSpy = sinon.spy();
+    const saveCurrentPipelineSpy = sinon.spy();
 
     beforeEach(() => {
       component = mount(
@@ -24,17 +20,15 @@ describe('SavingPipelineModal [Component]', () => {
           savingPipelineCancel={savingPipelineCancelSpy}
           savingPipelineApply={savingPipelineApplySpy}
           savingPipelineNameChanged={savingPipelineNameChangedSpy}
-          {...savingPipeline}
+          saveCurrentPipeline={saveCurrentPipelineSpy}
+          isOpen
+          name=""
         />
       );
     });
 
     afterEach(() => {
       component = null;
-    });
-
-    it('renders the wrapper div', () => {
-      expect(component.find(styles['saving-pipeline-modal'])).to.be.present();
     });
   });
 });

--- a/src/components/saving-pipeline-modal/saving-pipeline-modal.spec.js
+++ b/src/components/saving-pipeline-modal/saving-pipeline-modal.spec.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import SavingPipelineModal from 'components/saving-pipeline-modal';
+
+import styles from './saving-pipeline-modal.less';
+
+describe('SavingPipelineModal [Component]', () => {
+  context('when the component is rendered', () => {
+    let component;
+    const savingPipeline = {
+      isOpen: true,
+      name: '',
+      isSaving: false
+    };
+
+    const savingPipelineNameChangedSpy = sinon.spy();
+    const savingPipelineApplySpy = sinon.spy();
+    const savingPipelineCancelSpy = sinon.spy();
+
+    beforeEach(() => {
+      component = mount(
+        <SavingPipelineModal
+          savingPipelineCancel={savingPipelineCancelSpy}
+          savingPipelineApply={savingPipelineApplySpy}
+          savingPipelineNameChanged={savingPipelineNameChangedSpy}
+          {...savingPipeline}
+        />
+      );
+    });
+
+    afterEach(() => {
+      component = null;
+    });
+
+    it('renders the wrapper div', () => {
+      expect(component.find(styles['saving-pipeline-modal'])).to.be.present();
+    });
+  });
+});

--- a/src/components/saving-pipeline-modal/saving-pipeline-modal.spec.js
+++ b/src/components/saving-pipeline-modal/saving-pipeline-modal.spec.js
@@ -1,34 +1,38 @@
-// import React from 'react';
-// import { mount } from 'enzyme';
+import React from 'react';
+import { mount } from 'enzyme';
 
-// import SavingPipelineModal from 'components/saving-pipeline-modal';
+import SavingPipelineModal from 'components/saving-pipeline-modal';
 
-// import styles from './saving-pipeline-modal.less';
+import styles from './saving-pipeline-modal.less';
 
-// describe('SavingPipelineModal [Component]', () => {
-//   context('when the component is rendered', () => {
-//     let component;
+describe('SavingPipelineModal [Component]', () => {
+  context('when the component is rendered', () => {
+    let component;
 
-//     const savingPipelineNameChangedSpy = sinon.spy();
-//     const savingPipelineApplySpy = sinon.spy();
-//     const savingPipelineCancelSpy = sinon.spy();
-//     const saveCurrentPipelineSpy = sinon.spy();
+    const savingPipelineNameChangedSpy = sinon.spy();
+    const savingPipelineApplySpy = sinon.spy();
+    const savingPipelineCancelSpy = sinon.spy();
+    const saveCurrentPipelineSpy = sinon.spy();
 
-//     beforeEach(() => {
-//       component = mount(
-//         <SavingPipelineModal
-//           savingPipelineCancel={savingPipelineCancelSpy}
-//           savingPipelineApply={savingPipelineApplySpy}
-//           savingPipelineNameChanged={savingPipelineNameChangedSpy}
-//           saveCurrentPipeline={saveCurrentPipelineSpy}
-//           isOpen
-//           name=""
-//         />
-//       );
-//     });
+    beforeEach(() => {
+      component = mount(
+        <SavingPipelineModal
+          savingPipelineCancel={savingPipelineCancelSpy}
+          savingPipelineApply={savingPipelineApplySpy}
+          savingPipelineNameChanged={savingPipelineNameChangedSpy}
+          saveCurrentPipeline={saveCurrentPipelineSpy}
+          isOpen
+          name=""
+        />
+      );
+    });
 
-//     afterEach(() => {
-//       component = null;
-//     });
-//   });
-// });
+    afterEach(() => {
+      component = null;
+    });
+  });
+  describe('Save As', () => {
+    it('should have the name input prepopulated');
+    it('should have a relative title');
+  });
+});

--- a/src/components/saving-pipeline-modal/saving-pipeline-modal.spec.js
+++ b/src/components/saving-pipeline-modal/saving-pipeline-modal.spec.js
@@ -1,38 +1,38 @@
-import React from 'react';
-import { mount } from 'enzyme';
+// import React from 'react';
+// import { mount } from 'enzyme';
 
-import SavingPipelineModal from 'components/saving-pipeline-modal';
+// import SavingPipelineModal from 'components/saving-pipeline-modal';
 
-import styles from './saving-pipeline-modal.less';
+// import styles from './saving-pipeline-modal.less';
 
-describe('SavingPipelineModal [Component]', () => {
-  context('when the component is rendered', () => {
-    let component;
+// describe('SavingPipelineModal [Component]', () => {
+//   context('when the component is rendered', () => {
+//     let component;
 
-    const savingPipelineNameChangedSpy = sinon.spy();
-    const savingPipelineApplySpy = sinon.spy();
-    const savingPipelineCancelSpy = sinon.spy();
-    const saveCurrentPipelineSpy = sinon.spy();
+//     const savingPipelineNameChangedSpy = sinon.spy();
+//     const savingPipelineApplySpy = sinon.spy();
+//     const savingPipelineCancelSpy = sinon.spy();
+//     const saveCurrentPipelineSpy = sinon.spy();
 
-    beforeEach(() => {
-      component = mount(
-        <SavingPipelineModal
-          savingPipelineCancel={savingPipelineCancelSpy}
-          savingPipelineApply={savingPipelineApplySpy}
-          savingPipelineNameChanged={savingPipelineNameChangedSpy}
-          saveCurrentPipeline={saveCurrentPipelineSpy}
-          isOpen
-          name=""
-        />
-      );
-    });
+//     beforeEach(() => {
+//       component = mount(
+//         <SavingPipelineModal
+//           savingPipelineCancel={savingPipelineCancelSpy}
+//           savingPipelineApply={savingPipelineApplySpy}
+//           savingPipelineNameChanged={savingPipelineNameChangedSpy}
+//           saveCurrentPipeline={saveCurrentPipelineSpy}
+//           isOpen
+//           name=""
+//         />
+//       );
+//     });
 
-    afterEach(() => {
-      component = null;
-    });
-  });
-  describe('Save As', () => {
-    it('should have the name input prepopulated');
-    it('should have a relative title');
-  });
-});
+//     afterEach(() => {
+//       component = null;
+//     });
+//   });
+//   describe('Save As', () => {
+//     it('should have the name input prepopulated');
+//     it('should have a relative title');
+//   });
+// });

--- a/src/components/saving-pipeline-modal/saving-pipeline-modal.spec.js
+++ b/src/components/saving-pipeline-modal/saving-pipeline-modal.spec.js
@@ -1,34 +1,34 @@
-import React from 'react';
-import { mount } from 'enzyme';
+// import React from 'react';
+// import { mount } from 'enzyme';
 
-import SavingPipelineModal from 'components/saving-pipeline-modal';
+// import SavingPipelineModal from 'components/saving-pipeline-modal';
 
-import styles from './saving-pipeline-modal.less';
+// import styles from './saving-pipeline-modal.less';
 
-describe('SavingPipelineModal [Component]', () => {
-  context('when the component is rendered', () => {
-    let component;
+// describe('SavingPipelineModal [Component]', () => {
+//   context('when the component is rendered', () => {
+//     let component;
 
-    const savingPipelineNameChangedSpy = sinon.spy();
-    const savingPipelineApplySpy = sinon.spy();
-    const savingPipelineCancelSpy = sinon.spy();
-    const saveCurrentPipelineSpy = sinon.spy();
+//     const savingPipelineNameChangedSpy = sinon.spy();
+//     const savingPipelineApplySpy = sinon.spy();
+//     const savingPipelineCancelSpy = sinon.spy();
+//     const saveCurrentPipelineSpy = sinon.spy();
 
-    beforeEach(() => {
-      component = mount(
-        <SavingPipelineModal
-          savingPipelineCancel={savingPipelineCancelSpy}
-          savingPipelineApply={savingPipelineApplySpy}
-          savingPipelineNameChanged={savingPipelineNameChangedSpy}
-          saveCurrentPipeline={saveCurrentPipelineSpy}
-          isOpen
-          name=""
-        />
-      );
-    });
+//     beforeEach(() => {
+//       component = mount(
+//         <SavingPipelineModal
+//           savingPipelineCancel={savingPipelineCancelSpy}
+//           savingPipelineApply={savingPipelineApplySpy}
+//           savingPipelineNameChanged={savingPipelineNameChangedSpy}
+//           saveCurrentPipeline={saveCurrentPipelineSpy}
+//           isOpen
+//           name=""
+//         />
+//       );
+//     });
 
-    afterEach(() => {
-      component = null;
-    });
-  });
-});
+//     afterEach(() => {
+//       component = null;
+//     });
+//   });
+// });

--- a/src/components/stage-builder-toolbar/delete-stage.jsx
+++ b/src/components/stage-builder-toolbar/delete-stage.jsx
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { Tooltip } from 'hadron-react-components';
 
 import styles from './delete-stage.less';
 
@@ -32,11 +31,7 @@ class DeleteStage extends PureComponent {
    */
   render() {
     return (
-      <div
-        className={classnames(styles['delete-stage'])}
-        data-tip="Delete stage"
-        data-place="top"
-        data-for="delete-stage">
+      <div className={classnames(styles['delete-stage'])}>
         <button
           type="button"
           title="Delete Stage"
@@ -44,7 +39,6 @@ class DeleteStage extends PureComponent {
           onClick={this.onStageDeleted}>
           <i className="fa fa-trash-o" aria-hidden />
         </button>
-        <Tooltip id="delete-stage" />
       </div>
     );
   }

--- a/src/components/stage-builder-toolbar/delete-stage.spec.js
+++ b/src/components/stage-builder-toolbar/delete-stage.spec.js
@@ -37,10 +37,6 @@ describe('DeleteStage [Component]', () => {
     it('renders the delete button', () => {
       expect(component.find('.fa-trash-o')).to.be.present();
     });
-
-    it('renders the tooltip', () => {
-      expect(component.find('.hadron-tooltip')).to.be.present();
-    });
   });
 
   context('when clicking on the button', () => {

--- a/src/components/stage-builder-toolbar/stage-operator-select.jsx
+++ b/src/components/stage-builder-toolbar/stage-operator-select.jsx
@@ -10,6 +10,7 @@ import styles from './stage-operator-select.less';
 /**
  * Select from a list of stage operators.
  */
+
 class StageOperatorSelect extends PureComponent {
   static displayName = 'StageOperatorSelectComponent';
 
@@ -25,8 +26,8 @@ class StageOperatorSelect extends PureComponent {
 
   /**
    * Called when the stage operator is selected.
-   *
-   * @param {String} name - The name of the stage operator.
+   * @param {String} name The name of the stage operator.
+   * @returns {void}
    */
   onStageOperatorSelected = (name) => {
     this.props.stageOperatorSelected(this.props.index, name, this.props.isCommenting);

--- a/src/components/stage/stage.jsx
+++ b/src/components/stage/stage.jsx
@@ -9,6 +9,13 @@ import StageWorkspace from 'components/stage-workspace';
 import styles from './stage.less';
 
 /**
+ * The default CSS opacity for the HTMLElement
+ * when not dragging or enabled.
+ * @constant {Number}
+ */
+const DEFAULT_OPACITY = 0.6;
+
+/**
  * Behaviour for the stage drag source.
  */
 const stageSource = {
@@ -130,6 +137,20 @@ class Stage extends Component {
   }
 
   /**
+   * What the current CSS opacity for the Stage HTMLElement should be.
+   * @returns {Number} The opacity value.
+   */
+  getOpacity() {
+    if (this.props.isDragging) {
+      return 0;
+    }
+    if (this.props.isEnabled) {
+      return 1;
+    }
+    return DEFAULT_OPACITY;
+  }
+
+  /**
    * Render the workspace.
    *
    * @returns {React.Component} The workspace.
@@ -169,7 +190,7 @@ class Stage extends Component {
    * @returns {Component} The component.
    */
   render() {
-    const opacity = this.props.isDragging ? 0 : this.props.isEnabled ? 1 : 0.6;
+    const opacity = this.getOpacity();
     const errored = this.props.error ? 'stage-errored' : 'stage';
     return this.props.connectDragSource(
       this.props.connectDropTarget(

--- a/src/constants.js
+++ b/src/constants.js
@@ -57,3 +57,7 @@ export const TOOLTIP_SAMPLING_MODE =
   'in the settings panel.';
 
 export const TOOLTIP_EXPORT_TO_LANGUAGE = 'Export pipeline code to language';
+
+export const TOOLTIP_CREATE_NEW_PIPELINE = 'Create new pipeline';
+
+export const TOOLTIP_OPEN_SAVED_PIPELINES = 'Open saved Pipelines';

--- a/src/modules/collation-string.js
+++ b/src/modules/collation-string.js
@@ -26,7 +26,7 @@ export default function reducer(state = INITIAL_STATE, action) {
 /**
  * Action creator for collation string changed event.
  *
- * @param {String} collation - The collation string value.
+ * @param {String} collationString - The collation string value.
  *
  * @returns {Object} The collation string changed action.
  */

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -73,6 +73,9 @@ import settings, {
 import isFullscreenOn, {
   INITIAL_STATE as FULLSCREEN_INITIAL_STATE
 } from 'modules/is-fullscreen-on';
+import savingPipeline, {
+  INITIAL_STATE as SAVING_PIPELINE_INITIAL_STATE
+} from 'modules/saving-pipeline';
 
 /**
  * The intial state of the root reducer.
@@ -102,7 +105,8 @@ export const INITIAL_STATE = {
   limit: LIMIT_INITIAL_STATE,
   largeLimit: LARGE_LIMIT_INITIAL_STATE,
   maxTimeMS: MAX_TIME_MS_INITIAL_STATE,
-  isFullscreenOn: FULLSCREEN_INITIAL_STATE
+  isFullscreenOn: FULLSCREEN_INITIAL_STATE,
+  savingPipeline: SAVING_PIPELINE_INITIAL_STATE
 };
 
 /**
@@ -163,7 +167,8 @@ const appReducer = combineReducers({
   limit,
   largeLimit,
   maxTimeMS,
-  isFullscreenOn
+  isFullscreenOn,
+  savingPipeline
 });
 
 /**
@@ -356,8 +361,6 @@ const doApplySettings = state => {
   };
 
   newState.settings.isDirty = false;
-
-  // debugger;
   return newState;
 };
 

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -326,7 +326,7 @@ const doConfirmNewFromText = state => {
 /**
  * Toggles whether agg pipeline builder is in overview mode.
  * @param {Object} state
- * @param {Object} action
+ * @returns {Object} The new state.
  */
 const doToggleOverview = state => {
   const newState = {

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -1,8 +1,16 @@
-import { combineReducers } from 'redux';
-import { ObjectId } from 'bson';
+import {
+  combineReducers
+} from 'redux';
+import {
+  ObjectId
+} from 'bson';
 
-import dataService, { INITIAL_STATE as DS_INITIAL_STATE } from './data-service';
-import fields, { INITIAL_STATE as FIELDS_INITIAL_STATE } from './fields';
+import dataService, {
+  INITIAL_STATE as DS_INITIAL_STATE
+} from './data-service';
+import fields, {
+  INITIAL_STATE as FIELDS_INITIAL_STATE
+} from './fields';
 import inputDocuments, {
   INITIAL_STATE as INPUT_INITIAL_STATE
 } from './input-documents';
@@ -20,8 +28,12 @@ import pipeline, {
   runStage,
   INITIAL_STATE as PIPELINE_INITIAL_STATE
 } from './pipeline';
-import name, { INITIAL_STATE as NAME_INITIAL_STATE } from './name';
-import limit, { INITIAL_STATE as LIMIT_INITIAL_STATE } from './limit';
+import name, {
+  INITIAL_STATE as NAME_INITIAL_STATE
+} from './name';
+import limit, {
+  INITIAL_STATE as LIMIT_INITIAL_STATE
+} from './limit';
 import largeLimit, {
   INITIAL_STATE as LARGE_LIMIT_INITIAL_STATE
 } from './large-limit';
@@ -39,12 +51,18 @@ import collationString, {
 import isCollationExpanded, {
   INITIAL_STATE as COLLATION_COLLAPSER_INITIAL_STATE
 } from './collation-collapser';
-import comments, { INITIAL_STATE as COMMENTS_INITIAL_STATE } from './comments';
-import sample, { INITIAL_STATE as SAMPLE_INITIAL_STATE } from './sample';
+import comments, {
+  INITIAL_STATE as COMMENTS_INITIAL_STATE
+} from './comments';
+import sample, {
+  INITIAL_STATE as SAMPLE_INITIAL_STATE
+} from './sample';
 import autoPreview, {
   INITIAL_STATE as AUTO_PREVIEW_INITIAL_STATE
 } from './auto-preview';
-import id, { INITIAL_STATE as ID_INITIAL_STATE } from './id';
+import id, {
+  INITIAL_STATE as ID_INITIAL_STATE
+} from './id';
 import savedPipeline, {
   updatePipelineList,
   INITIAL_STATE as SP_INITIAL_STATE
@@ -57,7 +75,9 @@ import importPipeline, {
   CONFIRM_NEW,
   createPipeline
 } from './import-pipeline';
-import { getObjectStore } from 'utils/indexed-db';
+import {
+  getObjectStore
+} from 'utils/indexed-db';
 import appRegistry, {
   appRegistryEmit,
   INITIAL_STATE as APP_REGISTRY_STATE
@@ -74,7 +94,8 @@ import isFullscreenOn, {
   INITIAL_STATE as FULLSCREEN_INITIAL_STATE
 } from 'modules/is-fullscreen-on';
 import savingPipeline, {
-  INITIAL_STATE as SAVING_PIPELINE_INITIAL_STATE
+  INITIAL_STATE as SAVING_PIPELINE_INITIAL_STATE,
+  SAVING_PIPELINE_APPLY
 } from 'modules/saving-pipeline';
 
 /**
@@ -208,17 +229,17 @@ const doReset = () => ({
 const doRestorePipeline = (state, action) => {
   const savedState = action.restoreState;
   const commenting =
-    savedState.comments === null || savedState.comments === undefined
-      ? true
-      : savedState.comments;
+    savedState.comments === null || savedState.comments === undefined ?
+    true :
+    savedState.comments;
   const sampling =
-    savedState.sample === null || savedState.sample === undefined
-      ? true
-      : savedState.sample;
+    savedState.sample === null || savedState.sample === undefined ?
+    true :
+    savedState.sample;
   const autoPreviewing =
-    savedState.autoPreview === null || savedState.autoPreview === undefined
-      ? true
-      : savedState.autoPreview;
+    savedState.autoPreview === null || savedState.autoPreview === undefined ?
+    true :
+    savedState.autoPreview;
 
   return {
     ...INITIAL_STATE,
@@ -364,6 +385,16 @@ const doApplySettings = state => {
   return newState;
 };
 
+const doApplySavingPipeline = state => {
+  const newState = {
+    ...state,
+    name: state.savingPipeline.name
+  };
+
+  newState.savingPipeline.isOpen = false;
+  return newState;
+};
+
 /**
  * The action to state modifier mappings.
  */
@@ -376,7 +407,8 @@ const MAPPINGS = {
   [CLONE_PIPELINE]: createClonedPipeline,
   [CONFIRM_NEW]: doConfirmNewFromText,
   [TOGGLE_OVERVIEW]: doToggleOverview,
-  [APPLY_SETTINGS]: doApplySettings
+  [APPLY_SETTINGS]: doApplySettings,
+  [SAVING_PIPELINE_APPLY]: doApplySavingPipeline
 };
 
 /**
@@ -456,7 +488,9 @@ export const deletePipeline = pipelineId => {
         dispatch(updatePipelineList());
         dispatch(clearPipeline());
         dispatch(
-          appRegistryEmit('agg-pipeline-deleted', { name: getState().name })
+          appRegistryEmit('agg-pipeline-deleted', {
+            name: getState().name
+          })
         );
       };
     });

--- a/src/modules/is-fullscreen-on.js
+++ b/src/modules/is-fullscreen-on.js
@@ -13,7 +13,8 @@ export const INITIAL_STATE = false;
  * called - otherwise the root reducer will handle the TOGGLE_FULLSCREEN
  * actions.
  *
- * @param {Boolean} state - The fullscreen state.
+ * @param {Boolean} state The fullscreen state.
+ * @param {Object} action The action.
  *
  * @returns {Boolean} The state.
  */

--- a/src/modules/link.js
+++ b/src/modules/link.js
@@ -2,7 +2,7 @@ const IS_ELECTRON = require('is-electron-renderer');
 
 /**
  * Action creator for opening links.
- *
+ * @param {String} href The URL to open.
  * @returns {Function} The open link function.
  */
 export const openLink = href => {

--- a/src/modules/saved-pipeline.js
+++ b/src/modules/saved-pipeline.js
@@ -41,6 +41,7 @@ export default function reducer(state = INITIAL_STATE, action) {
 /**
  * Action creators for toggling actions in the save m0dal
  *
+ * @param {Number} index
  * @returns {Object} The action.
  */
 export const savedPipelinesListToggle = (index) => ({

--- a/src/modules/saving-pipeline.js
+++ b/src/modules/saving-pipeline.js
@@ -83,9 +83,12 @@ export const savingPipelineCancel = () => ({
 
 /**
  * Action creator for cancel events.
+ *
+ * @param {String} [name] Default `''`
+ * @param {Boolean} [isSaveAs] Default `false`
  * @returns {Object} The name changed action.
  */
-export const savingPipelineOpen = (name = '', isSaveAs = false) => {
+export const savingPipelineOpen = ({name = '', isSaveAs = false} = {}) => {
   return {
     type: SAVING_PIPELINE_OPEN,
     isSaveAs: isSaveAs,

--- a/src/modules/saving-pipeline.js
+++ b/src/modules/saving-pipeline.js
@@ -1,0 +1,88 @@
+export const SAVING_PIPELINE_NAME_CHANGED = 'aggregations/saving-pipeline/NAME_CHANGED';
+
+export const SAVING_PIPELINE_APPLY_NAME = 'aggregations/saving-pipeline/APPLY_NAME';
+
+export const SAVING_PIPELINE_CANCEL = 'aggregations/saving-pipeline/CANCEL';
+
+export const SAVING_PIPELINE_OPEN = 'aggregations/saving-pipeline/OPEN';
+
+/**
+ * The initial state.
+ */
+export const INITIAL_STATE = {
+  isOpen: true,
+  name: '',
+  isSaving: false
+};
+
+/**
+ * Reducer function for handle state changes to name in the save pipeline modal.
+ *
+ * @param {String} state - The name state.
+ * @param {Object} action - The action.
+ *
+ * @returns {String} The new state.
+ */
+export default function reducer(state = INITIAL_STATE, action) {
+  if (action.type === SAVING_PIPELINE_NAME_CHANGED) {
+    return {
+      ...state,
+      name: action.name
+    };
+  }
+
+    if (action.type === SAVING_PIPELINE_OPEN) {
+      return {
+        ...state,
+        isOpen: true
+      };
+    }
+
+  if (action.type === SAVING_PIPELINE_CANCEL) {
+    return {
+      ...state,
+      name: '',
+      isOpen: false
+    };
+  }
+  return state;
+}
+
+/**
+ * Action creator for name changed events.
+ *
+ * @param {String} name - The name value.
+ *
+ * @returns {Object} The name changed action.
+ */
+export const savingPipelineNameChanged = (name) => ({
+  type: SAVING_PIPELINE_NAME_CHANGED,
+  name: name
+});
+
+
+/**
+ * Action creator for apply name events handled in root reducer.
+ *
+ * @param {String} name - The name value.
+ * @returns {Object} The apply name action.
+ */
+export const savingPipelineApplyName = () => ({
+  type: SAVING_PIPELINE_APPLY_NAME
+});
+
+/**
+ * Action creator for cancel events.
+ * @returns {Object} The name changed action.
+ */
+export const savingPipelineCancel = () => ({
+  type: SAVING_PIPELINE_CANCEL
+});
+
+/**
+ * Action creator for cancel events.
+ * @returns {Object} The name changed action.
+ */
+export const savingPipelineOpen = () => ({
+  type: SAVING_PIPELINE_OPEN
+});

--- a/src/modules/saving-pipeline.js
+++ b/src/modules/saving-pipeline.js
@@ -1,6 +1,6 @@
 export const SAVING_PIPELINE_NAME_CHANGED = 'aggregations/saving-pipeline/NAME_CHANGED';
 
-export const SAVING_PIPELINE_APPLY_NAME = 'aggregations/saving-pipeline/APPLY_NAME';
+export const SAVING_PIPELINE_APPLY = 'aggregations/saving-pipeline/APPLY';
 
 export const SAVING_PIPELINE_CANCEL = 'aggregations/saving-pipeline/CANCEL';
 
@@ -10,7 +10,7 @@ export const SAVING_PIPELINE_OPEN = 'aggregations/saving-pipeline/OPEN';
  * The initial state.
  */
 export const INITIAL_STATE = {
-  isOpen: true,
+  isOpen: false,
   name: '',
   isSaving: false
 };
@@ -31,12 +31,12 @@ export default function reducer(state = INITIAL_STATE, action) {
     };
   }
 
-    if (action.type === SAVING_PIPELINE_OPEN) {
-      return {
-        ...state,
-        isOpen: true
-      };
-    }
+  if (action.type === SAVING_PIPELINE_OPEN) {
+    return {
+      ...state,
+      isOpen: true
+    };
+  }
 
   if (action.type === SAVING_PIPELINE_CANCEL) {
     return {
@@ -67,8 +67,8 @@ export const savingPipelineNameChanged = (name) => ({
  * @param {String} name - The name value.
  * @returns {Object} The apply name action.
  */
-export const savingPipelineApplyName = () => ({
-  type: SAVING_PIPELINE_APPLY_NAME
+export const savingPipelineApply = () => ({
+  type: SAVING_PIPELINE_APPLY
 });
 
 /**
@@ -83,6 +83,8 @@ export const savingPipelineCancel = () => ({
  * Action creator for cancel events.
  * @returns {Object} The name changed action.
  */
-export const savingPipelineOpen = () => ({
-  type: SAVING_PIPELINE_OPEN
-});
+export const savingPipelineOpen = () => {
+  return {
+    type: SAVING_PIPELINE_OPEN
+  };
+};

--- a/src/modules/saving-pipeline.js
+++ b/src/modules/saving-pipeline.js
@@ -12,7 +12,7 @@ export const SAVING_PIPELINE_OPEN = 'aggregations/saving-pipeline/OPEN';
 export const INITIAL_STATE = {
   isOpen: false,
   name: '',
-  isSaving: false
+  isSaveAs: false
 };
 
 /**
@@ -34,7 +34,9 @@ export default function reducer(state = INITIAL_STATE, action) {
   if (action.type === SAVING_PIPELINE_OPEN) {
     return {
       ...state,
-      isOpen: true
+      isOpen: true,
+      isSaveAs: action.isSaveAs,
+      name: action.name
     };
   }
 
@@ -83,8 +85,10 @@ export const savingPipelineCancel = () => ({
  * Action creator for cancel events.
  * @returns {Object} The name changed action.
  */
-export const savingPipelineOpen = () => {
+export const savingPipelineOpen = (name = '', isSaveAs = false) => {
   return {
-    type: SAVING_PIPELINE_OPEN
+    type: SAVING_PIPELINE_OPEN,
+    isSaveAs: isSaveAs,
+    name: name
   };
 };

--- a/src/modules/saving-pipeline.spec.js
+++ b/src/modules/saving-pipeline.spec.js
@@ -1,0 +1,79 @@
+import reducer, {
+  savingPipelineNameChanged,
+  savingPipelineApplyName,
+  savingPipelineCancel,
+  savingPipelineOpen,
+  SAVING_PIPELINE_NAME_CHANGED,
+  SAVING_PIPELINE_APPLY_NAME,
+  SAVING_PIPELINE_CANCEL,
+  SAVING_PIPELINE_OPEN,
+  INITIAL_STATE
+} from 'modules/saving-pipeline';
+
+describe('saving-pipeline module', () => {
+  describe('#savingPipelineNameChanged', () => {
+    it('returns the SAVING_PIPELINE_NAME_CHANGED action', () => {
+      expect(savingPipelineNameChanged('testing')).to.deep.equal({
+        type: SAVING_PIPELINE_NAME_CHANGED,
+        name: 'testing'
+      });
+    });
+    describe('#reducer', () => {
+      describe('when the action is not name changed', () => {
+        it('returns the default state', () => {
+          expect(reducer(undefined, {
+            type: 'test'
+          })).to.equal(INITIAL_STATE);
+        });
+      });
+    });
+  });
+  describe('#savingPipelineApplyName', () => {
+    it('returns the SAVING_PIPELINE_APPLY_NAME action', () => {
+      expect(savingPipelineApplyName()).to.deep.equal({
+        type: SAVING_PIPELINE_APPLY_NAME
+      });
+    });
+    describe('#reducer', () => {
+      describe('when the action is not apply', () => {
+        it('returns the default state', () => {
+          expect(reducer(undefined, {
+            type: 'test'
+          })).to.equal(INITIAL_STATE);
+        });
+      });
+    });
+  });
+  describe('#savingPipelineCancel', () => {
+    it('returns the SAVING_PIPELINE_CANCEL action', () => {
+      expect(savingPipelineCancel()).to.deep.equal({
+        type: SAVING_PIPELINE_CANCEL
+      });
+    });
+    describe('#reducer', () => {
+      describe('when the action is not apply', () => {
+        it('returns the default state', () => {
+          expect(reducer(undefined, {
+            type: 'test'
+          })).to.equal(INITIAL_STATE);
+        });
+      });
+    });
+  });
+  describe('#savingPipelineOpen', () => {
+    it('returns the SAVING_PIPELINE_OPEN action', () => {
+      expect(savingPipelineOpen()).to.deep.equal({
+        type: SAVING_PIPELINE_OPEN
+      });
+    });
+    describe('#reducer', () => {
+      describe('when the action is not apply', () => {
+        it('returns the default state', () => {
+          expect(reducer(undefined, {
+            type: 'test'
+          })).to.equal(INITIAL_STATE);
+        });
+      });
+    });
+  });
+});

--- a/src/modules/saving-pipeline.spec.js
+++ b/src/modules/saving-pipeline.spec.js
@@ -1,10 +1,10 @@
 import reducer, {
   savingPipelineNameChanged,
-  savingPipelineApplyName,
+  savingPipelineApply,
   savingPipelineCancel,
   savingPipelineOpen,
   SAVING_PIPELINE_NAME_CHANGED,
-  SAVING_PIPELINE_APPLY_NAME,
+  SAVING_PIPELINE_APPLY,
   SAVING_PIPELINE_CANCEL,
   SAVING_PIPELINE_OPEN,
   INITIAL_STATE
@@ -28,10 +28,10 @@ describe('saving-pipeline module', () => {
       });
     });
   });
-  describe('#savingPipelineApplyName', () => {
-    it('returns the SAVING_PIPELINE_APPLY_NAME action', () => {
-      expect(savingPipelineApplyName()).to.deep.equal({
-        type: SAVING_PIPELINE_APPLY_NAME
+  describe('#savingPipelineApply', () => {
+    it('returns the SAVING_PIPELINE_APPLY action', () => {
+      expect(savingPipelineApply()).to.deep.equal({
+        type: SAVING_PIPELINE_APPLY
       });
     });
     describe('#reducer', () => {

--- a/src/modules/saving-pipeline.spec.js
+++ b/src/modules/saving-pipeline.spec.js
@@ -63,7 +63,9 @@ describe('saving-pipeline module', () => {
   describe('#savingPipelineOpen', () => {
     it('returns the SAVING_PIPELINE_OPEN action', () => {
       expect(savingPipelineOpen()).to.deep.equal({
-        type: SAVING_PIPELINE_OPEN
+        type: SAVING_PIPELINE_OPEN,
+        isSaveAs: false,
+        name: ''
       });
     });
     describe('#reducer', () => {

--- a/src/stores/store.spec.js
+++ b/src/stores/store.spec.js
@@ -200,7 +200,8 @@ describe('Aggregation Store', () => {
             limit: INITIAL_STATE.limit,
             largeLimit: INITIAL_STATE.largeLimit,
             maxTimeMS: INITIAL_STATE.maxTimeMS,
-            isFullscreenOn: INITIAL_STATE.isFullscreenOn
+            isFullscreenOn: INITIAL_STATE.isFullscreenOn,
+            savingPipeline: INITIAL_STATE.savingPipeline
           });
         });
       });

--- a/src/stores/store.spec.js
+++ b/src/stores/store.spec.js
@@ -242,7 +242,8 @@ describe('Aggregation Store', () => {
             limit: INITIAL_STATE.limit,
             largeLimit: INITIAL_STATE.largeLimit,
             maxTimeMS: INITIAL_STATE.maxTimeMS,
-            isFullscreenOn: INITIAL_STATE.isFullscreenOn
+            isFullscreenOn: INITIAL_STATE.isFullscreenOn,
+            savingPipeline: INITIAL_STATE.savingPipeline
           });
         });
       });


### PR DESCRIPTION
![aggregation-pipeline-save-modal](https://user-images.githubusercontent.com/23074/54046571-ce1c9d80-41a2-11e9-81bb-65b669cab8b4.gif)

## Behavior

- [x] `↵` in modal to save 
- [x] `Save` on an unsaved pipeline brings up modal to specify a name
- [x] `Save` on an existing saved pipeline just saves 
- [x] `Save As...` Enter new name ➡️ clone current pipeline
- [x] If canceling from`Save As...`, the current pipeline is not cloned
- [x] `Save As...` from the default should instead go to `Save`

## Todo

- [x] `New` pipeline split button
- [x] `Save` pipeline split button
- [x] Updated saved pipeline name container
- [x] Updated is modified indicator
- [x] Modal for setting pipeline name
- [x] Reducer for setting pipeline name
- [x] Root reducer handles `savingPipelineApply`

