### PR TITLE
COMPASS-2888: Autocompletion includes projections

### DIFF
--- a/examples/stage-editor.stories.js
+++ b/examples/stage-editor.stories.js
@@ -92,3 +92,20 @@ storiesOf('Styling > StageEditor', module)
       </Provider>
     );
   });
+
+storiesOf('AutoCompletion', module)
+  .addDecorator(story => <ComponentPreview>{story()}</ComponentPreview>)
+  .add('Example > $project', () => {
+    /**
+     * TODO: Ace prop for triggering `autocomplete()` on render?
+     */
+    const store = configureStore({
+      ...INITIAL_STATE,
+      BASIC_EXAMPLE
+    });
+    return (
+      <Provider store={store}>
+        <StageEditor />
+      </Provider>
+    );
+  });

--- a/field-store/example.js
+++ b/field-store/example.js
@@ -1,0 +1,61 @@
+#! /usr/bin/env node --experimental-modules
+
+var ObjectId = require('bson').ObjectId;
+var doc = {
+  _id: new ObjectId('59a06674c8df9f3cd2ee7d52'),
+  name: 'Mercury',
+  type: 'Terrestrial planet',
+  orderFromSun: 1,
+  radius: {
+    value: 4879,
+    units: 'km'
+  },
+  mass: {
+    value: 3.3e23,
+    units: 'kg'
+  },
+  sma: {
+    value: 57910000,
+    units: 'km'
+  },
+  orbitalPeriod: {
+    value: 0.24,
+    units: 'years'
+  },
+  eccentricity: 0.2056,
+  meanOrbitalVelocity: {
+    value: 47.36,
+    units: 'km/sec'
+  },
+  rotationPeriod: {
+    value: 58.65,
+    units: 'days'
+  },
+  inclinationOfAxis: {
+    value: 0,
+    units: 'degrees'
+  },
+  meanTemperature: 125,
+  gravity: {
+    value: 3.24,
+    units: 'm/s^2'
+  },
+  escapeVelocity: {
+    value: 4.25,
+    units: 'km/sec'
+  },
+  meanDensity: 5.43,
+  atmosphericComposition: '',
+  numberOfMoons: 0,
+  hasRings: false,
+  hasMagneticField: true
+};
+
+const parse = require('./index.js');
+async function main() {
+  const result = await parse([doc]);
+  console.log(result);
+}
+
+main();
+

--- a/field-store/index.js
+++ b/field-store/index.js
@@ -1,0 +1,216 @@
+const mergeWith = require('lodash.mergewith');
+const isNumber = require('lodash.isnumber');
+const isString = require('lodash.isstring');
+const uniq = require('lodash.uniq');
+const isArray = require('lodash.isarray');
+const includes = require('lodash.includes');
+const pick = require('lodash.pick');
+const cloneDeep = require('lodash.clonedeep');
+const union = require('lodash.union');
+const parseSchema = require('mongodb-schema');
+
+const FIELDS = [
+  'name',
+  'path',
+  'count',
+  'type'
+];
+
+const ONE = 1;
+const FIELD = 'field';
+const VERSION_ZERO = '0.0.0';
+
+const state = {
+  fields: {},
+  topLevelFields: [],
+  aceFields: []
+};
+
+const getState = () => {
+  return state;
+};
+
+const setState = (s) => {
+  state.fields = s.fields;
+  state.topLevelFields = s.topLevelFields;
+  state.aceFields = s.aceFields;
+
+  return state;
+};
+
+const _mergeFields = (existingField, newField) => {
+  return mergeWith(
+    existingField,
+    newField,
+    function (objectValue, sourceValue, key) {
+      if (key === 'count') {
+        // counts add up
+        return isNumber(objectValue) ? objectValue + sourceValue : sourceValue;
+      }
+      if (key === 'type') {
+        // Avoid the merge of 'Array' with 'Array' case becoming
+        // an array with a single value, i.e. ['Array']
+        if (objectValue === sourceValue) {
+          return objectValue;
+        }
+        // arrays concatenate and de-duplicate
+        if (isString(objectValue)) {
+          return uniq([objectValue, sourceValue]);
+        }
+        return isArray(objectValue) ? uniq(objectValue.concat(sourceValue)) : sourceValue;
+      }
+      // all other keys are handled as per default
+      return undefined;
+    }
+  );
+};
+
+const _flattenedFields = (fields, nestedFields, rootField, arrayDepth = 1) => {
+  if (!nestedFields) {
+    return;
+  }
+
+  if (rootField) {
+    if (!fields[rootField.path].hasOwnProperty('nestedFields')) {
+      fields[rootField.path].nestedFields = [];
+    }
+    nestedFields.map((f) => {
+      if (!includes(fields[rootField.path].nestedFields, f.path)) {
+        fields[rootField.path].nestedFields.push(f.path);
+      }
+    });
+  }
+
+  for (const field of nestedFields) {
+    const existingField = fields[field.path] || {};
+    const newField = pick(field, FIELDS);
+    fields[field.path] = _mergeFields(existingField, newField);
+
+    // recursively search arrays and subdocuments
+    for (const type of field.types) {
+      if (type.name === 'Document') {
+        // add nested sub-fields
+        _flattenedFields(fields, type.fields, field);
+      }
+      if (type.name === 'Array') {
+        // add arrays of arrays or subdocuments
+        _flattenedArray(fields, type.types, field, arrayDepth);
+      }
+    }
+  }
+};
+
+/**
+ * Helper to recurse into the "types" of the mongodb-schema superstructure.
+ *
+ * @param {Object} fields      flattened list of fields to mutate
+ * @param {Array} nestedTypes  the "types" array currently being inspected
+ * @param {Object} field       current top level field on which to
+ *                             mutate dimensionality
+ * @param {Number} arrayDepth  track depth of the dimensionality recursion
+ */
+const _flattenedArray = (fields, nestedTypes, field, arrayDepth) => {
+  fields[field.path].dimensionality = arrayDepth;
+
+  // Arrays have no name, so can only recurse into arrays or subdocuments
+  for (const type of nestedTypes) {
+    if (type.name === 'Document') {
+      // recurse into nested sub-fields
+      _flattenedFields(fields, type.fields, field);
+    }
+    if (type.name === 'Array') {
+      // recurse into nested arrays (again)
+      _flattenedArray(fields, type.types, field, arrayDepth + 1);
+    }
+  }
+};
+
+/**
+ * Processes the fields in a format compatible with the ACE editor
+ * autocompleter.
+ *
+ * @param {Object} fields - The fields.
+ *
+ * @returns {Array} The array of autocomplete metadata.
+ */
+const _processAceFields = (fields) => {
+  return Object.keys(fields).map((key) => {
+    const field = (key.indexOf('.') > -1 || key.indexOf(' ') > -1) ? `"${key}"` : key;
+    return {
+      name: key,
+      value: field,
+      score: ONE,
+      meta: FIELD,
+      version: VERSION_ZERO
+    };
+  });
+};
+
+/**
+ * merges a schema with the existing FieldStore content.
+ *
+ * @param  {Object} schema  schema to process and merge
+ */
+const _mergeSchema = (schema) => {
+  const fields = cloneDeep(getState().fields);
+  const topLevelFields = [];
+
+  for (const field of schema.fields) {
+    const name = field.name;
+    topLevelFields.push(name);
+  }
+  _flattenedFields(fields, schema.fields);
+
+  const tlResult = union(getState().topLevelFields, topLevelFields);
+  const aResult = _processAceFields(fields);
+  return setState({
+    fields: fields,
+    topLevelFields: tlResult,
+    aceFields: aResult
+  });
+};
+
+/**
+ * processes documents returned from the ResetDocumentListStore and
+ * LoadMoreDocumentsStore.
+ *
+ * @param  {Array} documents  documents to process.
+ */
+async function processDocuments(documents) {
+  return new Promise((resolve, reject) => {
+    parseSchema(documents, {
+      storeValues: false
+    }, (err, schema) => {
+      if (err) {
+        return reject(err);
+      }
+      resolve(_mergeSchema(schema));
+    });
+  });
+}
+
+/**
+ * processes a single document returned from the InsertDocumentStore.
+ *
+ * @param  {Object} document     document to process.
+ */
+async function processSingleDocument(document) {
+  return new Promise((resolve) => {
+    resolve(processDocuments([document]));
+  });
+}
+
+/**
+ * processes a schema from the SchemaStore.
+ *
+ * @param  {Array} schema     the schema to merge with the existing state.
+ */
+async function processSchema(schema) {
+  return new Promise((resolve) => {
+    resolve(_mergeSchema(schema));
+  });
+}
+module.exports = processDocuments;
+module.exports.processDocuments = processDocuments;
+module.exports.processSchema = processSchema;
+module.exports.processSingleDocument = processSingleDocument;

--- a/field-store/package.json
+++ b/field-store/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "field-store",
+  "version": "0.0.0",
+  "dependencies": {
+    "lodash.clonedeep": "^4.5.0",
+    "lodash.includes": "^4.3.0",
+    "lodash.isarray": "^4.0.0",
+    "lodash.isnumber": "^3.0.3",
+    "lodash.isstring": "^4.0.1",
+    "lodash.mergewith": "^4.6.1",
+    "lodash.pick": "^4.4.0",
+    "lodash.union": "^4.6.0",
+    "lodash.uniq": "^4.5.0",
+    "mongodb-schema": "^8.2.3"
+  }
+}

--- a/src/modules/stage.js
+++ b/src/modules/stage.js
@@ -24,6 +24,27 @@ export function generateStage(state) {
     state.previewDocuments = [];
     return {};
   }
+
+  const projections = [];
+  if (state.stageOperator === '$project') {
+    const stageContents = stage[state.stageOperator];
+    Object.keys(stageContents).map((k) => {
+      const projection = stageContents[k];
+      if (projection) {
+        /**
+         * TODO (@imlucas) Make `Projection` shape same as `Field` in `FieldStore`
+         */
+        /**
+         * TODO (@imlucas) Recursive projection support? e.g. {_id: {price: "$price", storeId: "$storeId"}}
+         */
+        projections.push({
+          name: k,
+          value: JSON.stringify(projection)
+        });
+      }
+    });
+  }
+  state.projections = projections;
   state.isValid = true;
   state.syntaxError = null;
   return stage;
@@ -45,6 +66,7 @@ export function generateStageAsString(state) {
     state.previewDocuments = [];
     return '{}';
   }
+  
   state.isValid = true;
   state.syntaxError = null;
   return stage;

--- a/src/modules/stage.spec.js
+++ b/src/modules/stage.spec.js
@@ -150,6 +150,35 @@ describe('Stage module', () => {
       });
     });
 
+    describe('when the stage is $project', () => {
+      const stage = {
+        id: 0,
+        isEnabled: true,
+        isExpanded: true,
+        isValid: true,
+        snippet: '',
+        stageOperator: '$project',
+        stage: '{_id: 0, avg_price: {$avg: "$price"}}'
+      };
+      const res = generateStage(stage);
+      it('returns the stage', () => {
+        expect(res).to.deep.equal({
+          '$project': {
+            _id: 0,
+            avg_price: {
+              $avg: '$price'
+            }
+          }
+        });
+      });
+      it('does not include dropped projections', () => {
+        expect(stage.projections.length).to.equal(1);
+      });
+      it('detects the avg_price projection', () => {
+        expect(stage.projections[0].name).to.equal('avg_price');
+      });
+    });
+
     context('when the stage has multiple types', () => {
       const stage = {
         id: 0,


### PR DESCRIPTION
Fixes: [COMPASS-2888](https://jira.mongodb.org/browse/COMPASS-2888)

## Todo

- [x] MVP to detect projections in a stage

## Open Questions for Follow-up Tickets

1. Should projections that drop a field say `{_id: 0}` not show up in subsequent stage autocompletes?

> Only if 100% accurate which could be tricky.

2. Should projection autocomplete entries include the underlying type? Would be best effort like `price=type<Int>` ➡️ `avg_price: {$avg: "$price"}` ➡️ `avg_price=type<Int>`

> We don't expose types from FieldStore in mongodb-js/ace-autocompleter, so that would need to come first.

3. Should we support other operators that create projection? Take at look at the below + est complexity (ht @mmarcon)

* `$project`
* `$addFields`
* `$bucket`
* `$bucketAuto`
* `$count`
* `$facet`
* `$graphLookup`
* `$group`
* `$lookup`
* `$replaceRoot`
* `$unwind`
* `$collStats` //Happy to ignore this if it's work specific to this operator
* `$indexStats` //again, happy to ignore