### PR TITLE
Use new global.less in electron harness

### DIFF
--- a/electron/renderer/index.js
+++ b/electron/renderer/index.js
@@ -8,8 +8,7 @@ import AggregationsPlugin, { activate } from 'plugin';
 // Import global less file. Note: these styles WILL NOT be used in compass, as compass provides its own set
 // of global styles. If you are wishing to style a given component, you should be writing a less file per
 // component as per the CSS Modules ICSS spec. @see src/components/toggle-button for an example.
-import 'bootstrap/less/bootstrap.less';
-import 'less/index.less';
+import 'less/global.less';
 
 const appRegistry = new AppRegistry();
 


### PR DESCRIPTION
Fixes buttons and other globals set from `10gen/compass` to correctly apply in electron via `npm start`. `less/global.less` properly monkeys around bootstrap, font-awesome, etc. so it can be a black box going forward for any future refactoring. No change needed for storybook as it already has this.