### PR TITLE
COMPASS-3086: Paste pipeline into empty stage to import

### DIFF
--- a/src/components/aggregations/aggregations.jsx
+++ b/src/components/aggregations/aggregations.jsx
@@ -44,7 +44,11 @@ import {
   getSavedPipelines
 } from 'modules/saved-pipeline';
 import { setIsModified } from 'modules/is-modified';
-import { restoreSavedPipeline, getPipelineFromIndexedDB } from 'modules/index';
+import {
+  newPipelineFromPaste,
+  restoreSavedPipeline,
+  getPipelineFromIndexedDB
+} from 'modules/index';
 import {
   restorePipelineModalToggle,
   restorePipelineFrom
@@ -196,7 +200,8 @@ const MappedAggregations = connect(
     savingPipelineApply,
     savingPipelineCancel,
     savingPipelineOpen,
-    projectionsChanged
+    projectionsChanged,
+    newPipelineFromPaste
   }
 )(Aggregations);
 

--- a/src/components/pipeline-workspace/pipeline-workspace.jsx
+++ b/src/components/pipeline-workspace/pipeline-workspace.jsx
@@ -40,7 +40,8 @@ class PipelineWorkspace extends PureComponent {
     fields: PropTypes.array.isRequired,
     isOverviewOn: PropTypes.bool.isRequired,
     projections: PropTypes.array.isRequired,
-    projectionsChanged: PropTypes.func.isRequired
+    projectionsChanged: PropTypes.func.isRequired,
+    newPipelineFromPaste: PropTypes.func.isRequired
   };
 
   /**
@@ -86,6 +87,7 @@ class PipelineWorkspace extends PureComponent {
           isOverviewOn={this.props.isOverviewOn}
           projections={this.props.projections}
           projectionsChanged={this.props.projectionsChanged}
+          newPipelineFromPaste={this.props.newPipelineFromPaste}
         />
       );
     });

--- a/src/components/pipeline/pipeline.jsx
+++ b/src/components/pipeline/pipeline.jsx
@@ -93,7 +93,8 @@ class Pipeline extends PureComponent {
     savingPipelineOpen: PropTypes.func.isRequired,
     savingPipeline: PropTypes.object.isRequired,
     projections: PropTypes.array.isRequired,
-    projectionsChanged: PropTypes.func.isRequired
+    projectionsChanged: PropTypes.func.isRequired,
+    newPipelineFromPaste: PropTypes.func.isRequired
   };
 
   /**

--- a/src/components/stage-editor/stage-editor.jsx
+++ b/src/components/stage-editor/stage-editor.jsx
@@ -51,7 +51,8 @@ class StageEditor extends Component {
     fromStageOperators: PropTypes.bool.isRequired,
     setIsModified: PropTypes.func.isRequired,
     projections: PropTypes.array.isRequired,
-    projectionsChanged: PropTypes.func.isRequired
+    projectionsChanged: PropTypes.func.isRequired,
+    newPipelineFromPaste: PropTypes.func.isRequired
   };
 
   static defaultProps = {
@@ -203,7 +204,7 @@ class StageEditor extends Component {
             mode="mongodb"
             theme="mongodb"
             width="100%"
-            readOnly={this.props.stageOperator === null}
+            // readOnly={this.props.stageOperator === null}
             value={this.props.stage}
             onChange={this.onStageChange}
             editorProps={{ $blockScrolling: Infinity }}
@@ -211,6 +212,15 @@ class StageEditor extends Component {
             setOptions={OPTIONS}
             onFocus={() => {
               tools.setCompleters([this.completer]);
+            }}
+            onChange={(contents) => {
+              if (
+                this.props.stageOperator === null &&
+                contents &&
+                contents.charAt(0) === '['
+              ) {
+                this.props.newPipelineFromPaste(contents);
+              }
             }}
             onLoad={(editor) => {
               this.editor = editor;

--- a/src/components/stage-workspace/stage-workspace.jsx
+++ b/src/components/stage-workspace/stage-workspace.jsx
@@ -34,7 +34,8 @@ class StageWorkspace extends PureComponent {
     setIsModified: PropTypes.func.isRequired,
     stageChanged: PropTypes.func.isRequired,
     projections: PropTypes.array.isRequired,
-    projectionsChanged: PropTypes.func.isRequired
+    projectionsChanged: PropTypes.func.isRequired,
+    newPipelineFromPaste: PropTypes.func.isRequired
   };
 
   /**
@@ -62,6 +63,7 @@ class StageWorkspace extends PureComponent {
           stageChanged={this.props.stageChanged}
           projections={this.props.projections}
           projectionsChanged={this.props.projectionsChanged}
+          newPipelineFromPaste={this.props.newPipelineFromPaste}
         />
         <StagePreview
           documents={this.props.previewDocuments}

--- a/src/components/stage/stage.jsx
+++ b/src/components/stage/stage.jsx
@@ -111,7 +111,8 @@ class Stage extends Component {
     fields: PropTypes.array.isRequired,
     setIsModified: PropTypes.func.isRequired,
     projections: PropTypes.array.isRequired,
-    projectionsChanged: PropTypes.func.isRequired
+    projectionsChanged: PropTypes.func.isRequired,
+    newPipelineFromPaste: PropTypes.func.isRequired
   };
 
   /* eslint complexity: 0 */
@@ -184,6 +185,7 @@ class Stage extends Component {
           stageChanged={this.props.stageChanged}
           projections={this.props.projections}
           projectionsChanged={this.props.projectionsChanged}
+          newPipelineFromPaste={this.props.newPipelineFromPaste}
         />
       );
     }

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -141,6 +141,8 @@ export const NEW_PIPELINE = 'aggregations/NEW_PIPELINE';
  */
 export const CLONE_PIPELINE = 'aggregations/CLONE_PIPELINE';
 
+export const NEW_FROM_PASTE = 'aggregations/NEW_FROM_PASTE';
+
 /**
  * The main application reducer.
  *
@@ -337,6 +339,30 @@ const doConfirmNewFromText = (state) => {
   };
 };
 
+const doNewFromPastedText = (state, action) => {
+  const pipe = createPipeline(action.text);
+  const error = pipe.length > 0 ? pipe[0].syntaxError : null;
+  if (error) {
+    return state;
+  }
+
+  return {
+    ...state,
+    name: '',
+    collation: {},
+    collationString: '',
+    isCollationExpanded: false,
+    id: new ObjectId().toHexString(),
+    pipeline: pipe,
+    importPipeline: {
+      isOpen: false,
+      isConfirmationNeeded: false,
+      text: action.text,
+      syntaxError: error
+    }
+  };
+};
+
 /**
  * Toggles whether agg pipeline builder is in overview mode.
  * @param {Object} state
@@ -414,7 +440,8 @@ const MAPPINGS = {
   [TOGGLE_OVERVIEW]: doToggleOverview,
   [APPLY_SETTINGS]: doApplySettings,
   [SAVING_PIPELINE_APPLY]: doApplySavingPipeline,
-  [PROJECTIONS_CHANGED]: doProjectionsChanged
+  [PROJECTIONS_CHANGED]: doProjectionsChanged,
+  [NEW_FROM_PASTE]: doNewFromPastedText
 };
 
 /**
@@ -478,6 +505,11 @@ export const newPipeline = () => ({
  */
 export const clonePipeline = () => ({
   type: CLONE_PIPELINE
+});
+
+export const newPipelineFromPaste = (text) => ({
+  type: NEW_FROM_PASTE,
+  text: text
 });
 
 /**

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -339,10 +339,29 @@ const doConfirmNewFromText = (state) => {
   };
 };
 
+/**
+ * When <StageEditor /> is empty and you paste
+ * what could be an aggregation pipeline.
+ *
+ * @see `newPipelineFromPaste()`
+ * @param {Object} state
+ * @param {Object} action
+ * @returns {Object}
+ */
 const doNewFromPastedText = (state, action) => {
   const pipe = createPipeline(action.text);
   const error = pipe.length > 0 ? pipe[0].syntaxError : null;
+  /**
+   * Do nothing if the text is not a valid pipeline.
+   */
   if (error) {
+    return state;
+  }
+
+  /**
+   * Do nothing if you have more than default first stage.
+   */
+  if (state.pipeline.length > 1) {
     return state;
   }
 
@@ -507,6 +526,12 @@ export const clonePipeline = () => ({
   type: CLONE_PIPELINE
 });
 
+/**
+ * Action creator <StageEditor /> calls if empty and you paste
+ * what could be an aggregation pipeline.
+ * @param {String} text
+ * @returns {Object}
+ */
 export const newPipelineFromPaste = (text) => ({
   type: NEW_FROM_PASTE,
   text: text


### PR DESCRIPTION
When <StageEditor /> is empty and you paste an aggregation pipeline as text, automatically populate the workspace with the complete text.

![compass-aggregations-paste-to-pipeline](https://user-images.githubusercontent.com/23074/55431990-c5c84000-555f-11e9-9887-aef86a28d350.gif)

Also handles pasted pipelines with more than one stage:
![compass-aggregations-paste-to-pipeline-2-stages](https://user-images.githubusercontent.com/23074/55432591-42a7e980-5561-11e9-9581-8dfec44e967f.gif)


