### PR TITLE
Add Pearson's rho example from @johnlpage

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -28,6 +28,12 @@ These are a base set of example aggregation's from @terakilobyte used in his M12
 
 [View in storybook](https://mongodb-js.github.io/compass-aggregations/?path=/story/examples--complex)
 
+### Pearson's rho
+
+[`example-pearsons-rho.js`](https://github.com/mongodb-js/compass-aggregations/blob/master/examples/example-pearsons-rho.js) calculates [the correlation co-efficient of two fields using Pearsons Rho](http://ilearnasigoalong.blogspot.com/2017/10/calculating-correlation-inside-mongodb.html). (HT @johnlpage)
+
+[View in storybook](https://mongodb-js.github.io/compass-aggregations/?path=/story/examples--pearsons-rho)
+
 ## Usage
 
 See [`aggregations.stories.js`](https://github.com/mongodb-js/compass-aggregations/blob/master/examples/aggregations.stories.js).

--- a/examples/aggregations.stories.js
+++ b/examples/aggregations.stories.js
@@ -11,6 +11,7 @@ import BASIC_EXAMPLE from './example-basic.js';
 import COMPLEX_EXAMPLE from './example-complex.js';
 import ARRAY_STATS_EXAMPLE from './example-array-stats.js';
 import GROUPED_STATS_EXAMPLE from './example-grouped-stats.js';
+import PEARSONS_RHO_EXAMPLE from './example-pearsons-rho.js';
 
 import DataService from './data-service-provider';
 
@@ -48,6 +49,7 @@ storiesOf('Examples', module)
   .add('Grouped Stats', () => loadAggregation(GROUPED_STATS_EXAMPLE))
   .add('Array Stats', () => loadAggregation(ARRAY_STATS_EXAMPLE))
   .add('Very Complex', () => loadAggregation(COMPLEX_EXAMPLE))
+  .add('Pearsons Rho', () => loadAggregation(PEARSONS_RHO_EXAMPLE))
   .add('Default', () => {
     const initialState = {
       ...BASE_STATE

--- a/examples/example-pearsons-rho.js
+++ b/examples/example-pearsons-rho.js
@@ -1,0 +1,100 @@
+import { EXAMPLE, STAGE_DEFAULTS } from './example-constants';
+import { ObjectId } from 'bson';
+
+/**
+ * Pearsons Rho as a pipeline from @johnlpage
+ * [Calculating Correlation inside MongoDB](http://ilearnasigoalong.blogspot.com/2017/10/calculating-correlation-inside-mongodb.html)
+ * > I've been pondering recently the idea of a library of statistical and heuristic functions that run inside MongoDB using the aggregation Pipeline.
+ * > After all if we can avoid pulling data out of the database that must help performance. As a little experiment, here is the correlation co-efficient
+ * > of two fields using Pearsons Rho. It's broken down into individual variables to make it easier to read rather than a huge piece of javascript.
+ * > That's usually the best way to write pipelines.
+ */
+const PEARSONS_RHO_EXAMPLE = {
+  ...EXAMPLE,
+  namespace: 'johnpage.pearsons',
+  pipeline: [
+    {
+      ...STAGE_DEFAULTS,
+      id: new ObjectId().toHexString(),
+      stageOperator: '$group',
+      stage: `{
+  _id: true,
+  count: {
+    $sum: 1
+  },
+  sumx: {
+    $sum: '$x'
+  },
+  sumy: {
+    $sum: '$y'
+  },
+  sumxsquared: {
+    $sum: {
+      $multiply: ['$x', '$x']
+    }
+  },
+  sumysquared: {
+    $sum: {
+      $multiply: ['$y', '$y']
+    }
+  },
+  sumxy: {
+    $sum: {
+      $multiply: ['$x', '$y']
+    }
+  }
+}`,
+      previewDocuments: []
+    },
+    {
+      ...STAGE_DEFAULTS,
+      id: new ObjectId().toHexString(),
+      stageOperator: '$project',
+      stage: `{
+  rho: {
+    $divide: [
+      {
+        $subtract: [
+          {
+            $multiply: ['$sumxy', '$count']
+          },
+          {
+            $multiply: ['$sumx', '$sumy']
+          }
+        ]
+      },
+      {
+        $sqrt: {
+          $multiply: [
+            {
+              $subtract: [
+                {
+                  $multiply: ['$sumxsquared', '$count']
+                },
+                {
+                  $multiply: ['$sumx', '$sumx']
+                }
+              ]
+            },
+            {
+              $subtract: [
+                {
+                  $multiply: ['$sumysquared', '$count']
+                },
+                {
+                  $multiply: ['$sumy', '$sumy']
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+}`,
+      previewDocuments: []
+    }
+  ]
+};
+
+export default PEARSONS_RHO_EXAMPLE;


### PR DESCRIPTION
A real-world analytics case from @johnlpage that calculates [the correlation co-efficient of two fields using Pearsons Rho](http://ilearnasigoalong.blogspot.com/2017/10/calculating-correlation-inside-mongodb.html).

Data added to the Compass free-tier Atlas w/ Stitch public read rules.

![Screenshot 2019-04-03 12 51 41](https://user-images.githubusercontent.com/23074/55497582-aab50900-560f-11e9-9cc2-2cc947f6cfde.png)
