### PR TITLE
Fix Warning: React version not specified

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,5 +17,10 @@
     "mongodb-js/browser",
     "mongodb-js/react"
   ],
-  "plugins": ["react"]
+  "plugins": ["react"],
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  }
 }


### PR DESCRIPTION
Warning: React version not specified in eslint-plugin-react settings. See https://github.com/yannickcr/eslint-plugin-react#configuration