### PR TITLE
COMPASS-3523: Create a view

### DIFF
--- a/examples/ create-view-modal.stories.js
+++ b/examples/ create-view-modal.stories.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { ComponentPreview } from 'storybook/decorators';
+
+import { Provider } from 'react-redux';
+import { INITIAL_STATE } from 'modules/create-view';
+import CreateViewModal from 'components/create-view-modal';
+
+import { configureStore } from 'utils/configureStore';
+
+const BASE_STATE = {
+  ...INITIAL_STATE
+};
+
+function loadAggregation(state = {}) {
+  const store = configureStore({
+    ...BASE_STATE,
+    ...state
+  });
+  return (
+    <Provider store={store}>
+      <CreateViewModal />
+    </Provider>
+  );
+}
+
+storiesOf('Examples/Create View', module)
+  .add('Default', () => {
+    const store = configureStore({
+      ...BASE_STATE
+    });
+    return (
+      <Provider store={store}>
+        <CreateViewModal />
+      </Provider>
+    );
+  })
+  .add('Visible', () => {
+    const store = configureStore({
+      ...BASE_STATE
+    });
+    return (
+      <Provider store={store}>
+        <CreateViewModal />
+      </Provider>
+    );
+  })
+  .add('Loading', () => {
+    const store = configureStore({
+      ...BASE_STATE,
+      isVisible: true,
+      isRunning: true,
+      name: 'myView'
+    });
+    return (
+      <Provider store={store}>
+        <CreateViewModal />
+      </Provider>
+    );
+  })
+  .add('Error', () => {
+    const store = configureStore({
+      ...BASE_STATE,
+      isVisible: true,
+      name: 'myView',
+      error: {
+        message: 'meeep!! Whats the error message?!'
+      }
+    });
+    return (
+      <Provider store={store}>
+        <CreateViewModal />
+      </Provider>
+    );
+  });

--- a/examples/create-view-modal.stories.js
+++ b/examples/create-view-modal.stories.js
@@ -1,43 +1,21 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { ComponentPreview } from 'storybook/decorators';
 
 import { Provider } from 'react-redux';
 import { INITIAL_STATE } from 'modules/create-view';
 import CreateViewModal from 'components/create-view-modal';
 
-import { configureStore } from 'utils/configureStore';
+import { configureCreateViewStore as configureStore } from 'utils/configureStore';
 
 const BASE_STATE = {
   ...INITIAL_STATE
 };
 
-function loadAggregation(state = {}) {
-  const store = configureStore({
-    ...BASE_STATE,
-    ...state
-  });
-  return (
-    <Provider store={store}>
-      <CreateViewModal />
-    </Provider>
-  );
-}
-
-storiesOf('Examples/Create View', module)
-  .add('Default', () => {
-    const store = configureStore({
-      ...BASE_STATE
-    });
-    return (
-      <Provider store={store}>
-        <CreateViewModal />
-      </Provider>
-    );
-  })
+storiesOf('Components/Create View', module)
   .add('Visible', () => {
     const store = configureStore({
-      ...BASE_STATE
+      ...BASE_STATE,
+      isVisible: true
     });
     return (
       <Provider store={store}>
@@ -66,6 +44,16 @@ storiesOf('Examples/Create View', module)
       error: {
         message: 'meeep!! Whats the error message?!'
       }
+    });
+    return (
+      <Provider store={store}>
+        <CreateViewModal />
+      </Provider>
+    );
+  })
+  .add('Default', () => {
+    const store = configureStore({
+      ...BASE_STATE
     });
     return (
       <Provider store={store}>

--- a/examples/pipeline-toolbar.stories.js
+++ b/examples/pipeline-toolbar.stories.js
@@ -1,59 +1,50 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { ComponentPreview } from 'storybook/decorators';
-
-import { Provider } from 'react-redux';
-import { INITIAL_STATE as BASE_STATE } from 'modules';
-
 import PipelineToolbar from 'components/pipeline-toolbar';
-import { configureStore } from 'utils/configureStore';
-
-import BASIC_EXAMPLE from './example-basic.js';
-
-const PROPS = {
-  ...BASE_STATE,
-  ...BASIC_EXAMPLE
-};
 
 import { action } from '@storybook/addon-actions';
 
+const DEFAULTS = {
+  serverVersion: '4.0.0',
+  savedPipelinesListToggle: action('savedPipelinesListToggle'),
+  getSavedPipelines: action('getSavedPipelines'),
+  newPipeline: action('newPipeline'),
+  newPipelineFromText: action('newPipelineFromText'),
+  clonePipeline: action('clonePipeline'),
+  exportToLanguage: action('exportToLanguage'),
+  saveCurrentPipeline: action('saveCurrentPipeline'),
+  savedPipeline: {
+    isNameValid: true
+  },
+  nameChanged: action('nameChanged'),
+  toggleComments: action('toggleComments'),
+  toggleSample: action('toggleSample'),
+  toggleAutoPreview: action('toggleAutoPreview'),
+  isModified: false,
+  isCommenting: true,
+  isSampling: true,
+  isAutoPreviewing: true,
+  setIsModified: action('setIsModified'),
+  name: '',
+  collationCollapseToggled: action('collationCollapseToggled'),
+  isCollationExpanded: false,
+  isOverviewOn: false,
+  isFullscreenOn: false,
+  toggleOverview: action('toggleOverview'),
+  toggleSettingsIsExpanded: action('toggleSettingsIsExpanded'),
+  toggleFullscreen: action('toggleFullscreen')
+};
 
 storiesOf('Components/PipelineToolbar', module)
-  .addDecorator(story => <ComponentPreview>{story()}</ComponentPreview>)
+  .addDecorator((story) => <ComponentPreview>{story()}</ComponentPreview>)
   .add('Default', () => {
-
-    const store = configureStore(PROPS);
-
+    return <PipelineToolbar {...DEFAULTS} />;
+  })
+  .add('Views/server@3.2.0', () => {
     const props = {
-      savedPipelinesListToggle: action('savedPipelinesListToggle'),
-      getSavedPipelines: action('getSavedPipelines'),
-      newPipeline: action('newPipeline'),
-      newPipelineFromText: action('newPipelineFromText'),
-      clonePipeline: action('clonePipeline'),
-      exportToLanguage: action('exportToLanguage'),
-      saveCurrentPipeline: action('saveCurrentPipeline'),
-      savedPipeline: {
-        isNameValid: true
-      },
-      nameChanged: action('nameChanged'),
-      toggleComments: action('toggleComments'),
-      toggleSample: action('toggleSample'),
-      toggleAutoPreview: action('toggleAutoPreview'),
-      isModified: false,
-      isCommenting: true,
-      isSampling: true,
-      isAutoPreviewing: true,
-      setIsModified: action('setIsModified'),
-      name: '',
-      collationCollapseToggled: action('collationCollapseToggled'),
-      isCollationExpanded: false,
-      isOverviewOn: false,
-      isFullscreenOn: false,
-      toggleOverview: action('toggleOverview'),
-      toggleSettingsIsExpanded: action('toggleSettingsIsExpanded'),
-      toggleFullscreen: action('toggleFullscreen'),
+      ...DEFAULTS,
+      serverVersion: '3.2.0'
     };
-    return (
-      <PipelineToolbar {...props}/>
-    );
+    return <PipelineToolbar {...props} />;
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -3322,13 +3322,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -3370,6 +3372,7 @@
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
+          "optional": true,
           "requires": {
             "remove-trailing-separator": "^1.0.1"
           }
@@ -9907,7 +9910,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -9928,12 +9932,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9948,17 +9954,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -10075,7 +10084,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -10087,6 +10097,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10101,6 +10112,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -10108,12 +10120,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -10132,6 +10146,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -10212,7 +10227,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -10224,6 +10240,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -10309,7 +10326,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -10345,6 +10363,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -10364,6 +10383,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -10407,12 +10427,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -10750,13 +10772,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -16314,9 +16338,9 @@
       }
     },
     "mongodb-data-service": {
-      "version": "12.5.1",
-      "resolved": "https://registry.npmjs.org/mongodb-data-service/-/mongodb-data-service-12.5.1.tgz",
-      "integrity": "sha512-s36/Qa/8c2+Fuz6F/hoWNqskp0BWk8yzfGQVRMz32Ra0SRxAnxYWLSUWL5UF/4i8vfNgOd2o+CtTnKeXB5FEVw==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb-data-service/-/mongodb-data-service-13.0.0.tgz",
+      "integrity": "sha512-sUUi4rpncMkdQ+95g5kuYJlruAmFCncJeYMPDnT0q2GOiKMgFhg6lJuGlfW07Mq4sWtFkGorJcFGF8ib8WjdaQ==",
       "dev": true,
       "requires": {
         "async": "^2.3.0",
@@ -16337,7 +16361,7 @@
         "lodash.uniqby": "^4.5.0",
         "mongodb": "^3.2.2",
         "mongodb-collection-sample": "^4.3.2",
-        "mongodb-connection-model": "^13.1.4",
+        "mongodb-connection-model": "^13.1.5",
         "mongodb-core": "^3.2.2",
         "mongodb-index-model": "^2.3.0",
         "mongodb-js-errors": "^0.3.3",
@@ -16347,6 +16371,390 @@
         "mongodb-url": "^3.0.1"
       },
       "dependencies": {
+        "ampersand-class-extend": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/ampersand-class-extend/-/ampersand-class-extend-1.0.2.tgz",
+          "integrity": "sha1-jjqxJdCb976UO1DpjM5G/1F8vpE=",
+          "dev": true,
+          "requires": {
+            "lodash.assign": "^3.0.0"
+          },
+          "dependencies": {
+            "lodash.assign": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+              "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
+              "dev": true,
+              "requires": {
+                "lodash._baseassign": "^3.0.0",
+                "lodash._createassigner": "^3.0.0",
+                "lodash.keys": "^3.0.0"
+              }
+            }
+          }
+        },
+        "ampersand-collection": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/ampersand-collection/-/ampersand-collection-1.6.1.tgz",
+          "integrity": "sha1-Qw9lTPcC4Z0drGzSEXVdUDFyoMk=",
+          "dev": true,
+          "requires": {
+            "ampersand-class-extend": "^1.0.0",
+            "ampersand-events": "^1.0.1",
+            "ampersand-version": "^1.0.2",
+            "lodash.assign": "^3.0.0",
+            "lodash.bind": "^3.1.0",
+            "lodash.isarray": "^3.0.1"
+          },
+          "dependencies": {
+            "lodash.assign": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+              "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
+              "dev": true,
+              "requires": {
+                "lodash._baseassign": "^3.0.0",
+                "lodash._createassigner": "^3.0.0",
+                "lodash.keys": "^3.0.0"
+              }
+            }
+          }
+        },
+        "ampersand-collection-lodash-mixin": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/ampersand-collection-lodash-mixin/-/ampersand-collection-lodash-mixin-2.0.1.tgz",
+          "integrity": "sha1-MdhfObWWnvfBNuC1A12+1FEc/XA=",
+          "dev": true,
+          "requires": {
+            "ampersand-version": "^1.0.0",
+            "lodash.countby": "^3.1.0",
+            "lodash.difference": "^3.1.0",
+            "lodash.drop": "^3.0.0",
+            "lodash.every": "^3.2.0",
+            "lodash.filter": "^3.1.0",
+            "lodash.find": "^3.2.0",
+            "lodash.foreach": "^3.0.2",
+            "lodash.groupby": "^3.1.0",
+            "lodash.includes": "^3.1.0",
+            "lodash.indexby": "^3.1.0",
+            "lodash.indexof": "^3.0.2",
+            "lodash.initial": "^3.0.0",
+            "lodash.invoke": "^3.1.0",
+            "lodash.isempty": "^3.0.1",
+            "lodash.isfunction": "^3.0.2",
+            "lodash.lastindexof": "^3.0.2",
+            "lodash.map": "^3.1.0",
+            "lodash.max": "^3.2.0",
+            "lodash.min": "^3.2.0",
+            "lodash.partition": "^3.1.0",
+            "lodash.reduce": "^3.1.0",
+            "lodash.reduceright": "^3.1.0",
+            "lodash.reject": "^3.1.0",
+            "lodash.rest": "^3.0.0",
+            "lodash.sample": "^3.0.0",
+            "lodash.shuffle": "^3.0.0",
+            "lodash.some": "^3.2.0",
+            "lodash.sortby": "^3.1.0",
+            "lodash.take": "^3.0.0",
+            "lodash.without": "^3.1.0"
+          },
+          "dependencies": {
+            "lodash.filter": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-3.1.1.tgz",
+              "integrity": "sha1-m7HUUzctnPkpEnw1Tfcj9Hri3D8=",
+              "dev": true,
+              "requires": {
+                "lodash._arrayfilter": "^3.0.0",
+                "lodash._basecallback": "^3.0.0",
+                "lodash._basefilter": "^3.0.0",
+                "lodash.isarray": "^3.0.0",
+                "lodash.keys": "^3.0.0"
+              }
+            },
+            "lodash.foreach": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-3.0.3.tgz",
+              "integrity": "sha1-b9fvt5aRrs1n/erCdhyY5wHWw5o=",
+              "dev": true,
+              "requires": {
+                "lodash._arrayeach": "^3.0.0",
+                "lodash._baseeach": "^3.0.0",
+                "lodash._bindcallback": "^3.0.0",
+                "lodash.isarray": "^3.0.0"
+              }
+            },
+            "lodash.groupby": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-3.1.1.tgz",
+              "integrity": "sha1-poj+Xysov2vn/22hyNT0oWdpXoI=",
+              "dev": true,
+              "requires": {
+                "lodash._createaggregator": "^3.0.0",
+                "lodash.keys": "^3.0.0"
+              }
+            },
+            "lodash.includes": {
+              "version": "3.1.3",
+              "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-3.1.3.tgz",
+              "integrity": "sha1-wyLQScJ4krKaAbmVk25ZU4HrvBc=",
+              "dev": true,
+              "requires": {
+                "lodash._baseindexof": "^3.0.0",
+                "lodash._basevalues": "^3.0.0",
+                "lodash._isiterateecall": "^3.0.0",
+                "lodash.isarray": "^3.0.0",
+                "lodash.isstring": "^3.0.0",
+                "lodash.keys": "^3.0.0"
+              }
+            },
+            "lodash.isstring": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-3.0.1.tgz",
+              "integrity": "sha1-QWOJROoELvZ61nwpOqVB0/PW5Tw=",
+              "dev": true
+            },
+            "lodash.map": {
+              "version": "3.1.4",
+              "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-3.1.4.tgz",
+              "integrity": "sha1-tIOs0beGxce0ksSV97UmYim8AMI=",
+              "dev": true,
+              "requires": {
+                "lodash._arraymap": "^3.0.0",
+                "lodash._basecallback": "^3.0.0",
+                "lodash._baseeach": "^3.0.0",
+                "lodash.isarray": "^3.0.0",
+                "lodash.keys": "^3.0.0"
+              }
+            }
+          }
+        },
+        "ampersand-collection-rest-mixin": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ampersand-collection-rest-mixin/-/ampersand-collection-rest-mixin-5.2.0.tgz",
+          "integrity": "sha1-tJTj5h3d3ngGg9mtlXaN1RS+YZQ=",
+          "dev": true,
+          "requires": {
+            "ampersand-sync": "^4.0.3",
+            "ampersand-version": "^1.0.2",
+            "lodash.assign": "^3.2.0"
+          },
+          "dependencies": {
+            "lodash.assign": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+              "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
+              "dev": true,
+              "requires": {
+                "lodash._baseassign": "^3.0.0",
+                "lodash._createassigner": "^3.0.0",
+                "lodash.keys": "^3.0.0"
+              }
+            }
+          }
+        },
+        "ampersand-events": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/ampersand-events/-/ampersand-events-1.1.1.tgz",
+          "integrity": "sha1-pQDpjMrorZKqHZV0TFM9nBChZTA=",
+          "dev": true,
+          "requires": {
+            "ampersand-version": "^1.0.2",
+            "lodash.assign": "^3.0.0",
+            "lodash.bind": "^3.1.0",
+            "lodash.foreach": "^3.0.2",
+            "lodash.isempty": "^3.0.1",
+            "lodash.keys": "^3.0.5",
+            "lodash.once": "^3.0.0",
+            "lodash.uniqueid": "^3.0.0"
+          },
+          "dependencies": {
+            "lodash.assign": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+              "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
+              "dev": true,
+              "requires": {
+                "lodash._baseassign": "^3.0.0",
+                "lodash._createassigner": "^3.0.0",
+                "lodash.keys": "^3.0.0"
+              }
+            },
+            "lodash.foreach": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-3.0.3.tgz",
+              "integrity": "sha1-b9fvt5aRrs1n/erCdhyY5wHWw5o=",
+              "dev": true,
+              "requires": {
+                "lodash._arrayeach": "^3.0.0",
+                "lodash._baseeach": "^3.0.0",
+                "lodash._bindcallback": "^3.0.0",
+                "lodash.isarray": "^3.0.0"
+              }
+            }
+          }
+        },
+        "ampersand-state": {
+          "version": "4.8.2",
+          "resolved": "https://registry.npmjs.org/ampersand-state/-/ampersand-state-4.8.2.tgz",
+          "integrity": "sha1-qPrjZakZ54S8icbqk6PzXvcvLDk=",
+          "dev": true,
+          "requires": {
+            "ampersand-events": "^1.1.1",
+            "ampersand-version": "^1.0.0",
+            "array-next": "~0.0.1",
+            "key-tree-store": "^1.3.0",
+            "lodash.assign": "^3.2.0",
+            "lodash.bind": "^3.1.0",
+            "lodash.escape": "^3.0.0",
+            "lodash.forown": "^3.0.2",
+            "lodash.has": "^3.0.0",
+            "lodash.includes": "^3.1.3",
+            "lodash.isarray": "^3.0.4",
+            "lodash.isdate": "^3.0.1",
+            "lodash.isequal": "^3.0.1",
+            "lodash.isfunction": "^3.0.6",
+            "lodash.isobject": "^3.0.1",
+            "lodash.isstring": "^3.0.1",
+            "lodash.omit": "^3.1.0",
+            "lodash.result": "^3.0.0",
+            "lodash.union": "^3.1.0",
+            "lodash.uniqueid": "^3.0.0"
+          },
+          "dependencies": {
+            "lodash.assign": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+              "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
+              "dev": true,
+              "requires": {
+                "lodash._baseassign": "^3.0.0",
+                "lodash._createassigner": "^3.0.0",
+                "lodash.keys": "^3.0.0"
+              }
+            },
+            "lodash.has": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-3.2.1.tgz",
+              "integrity": "sha1-O3VHHY0gg9itnYoV4yHseEJJWOY=",
+              "dev": true,
+              "requires": {
+                "lodash._baseget": "^3.0.0",
+                "lodash._baseslice": "^3.0.0",
+                "lodash._topath": "^3.0.0",
+                "lodash.isarguments": "^3.0.0",
+                "lodash.isarray": "^3.0.0"
+              }
+            },
+            "lodash.includes": {
+              "version": "3.1.3",
+              "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-3.1.3.tgz",
+              "integrity": "sha1-wyLQScJ4krKaAbmVk25ZU4HrvBc=",
+              "dev": true,
+              "requires": {
+                "lodash._baseindexof": "^3.0.0",
+                "lodash._basevalues": "^3.0.0",
+                "lodash._isiterateecall": "^3.0.0",
+                "lodash.isarray": "^3.0.0",
+                "lodash.isstring": "^3.0.0",
+                "lodash.keys": "^3.0.0"
+              }
+            },
+            "lodash.isstring": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-3.0.1.tgz",
+              "integrity": "sha1-QWOJROoELvZ61nwpOqVB0/PW5Tw=",
+              "dev": true
+            },
+            "lodash.omit": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
+              "integrity": "sha1-iX/jguZBPZrJfGH3jtHgV6AK+fM=",
+              "dev": true,
+              "requires": {
+                "lodash._arraymap": "^3.0.0",
+                "lodash._basedifference": "^3.0.0",
+                "lodash._baseflatten": "^3.0.0",
+                "lodash._bindcallback": "^3.0.0",
+                "lodash._pickbyarray": "^3.0.0",
+                "lodash._pickbycallback": "^3.0.0",
+                "lodash.keysin": "^3.0.0",
+                "lodash.restparam": "^3.0.0"
+              }
+            },
+            "lodash.union": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-3.1.0.tgz",
+              "integrity": "sha1-pKMGb8Fdan+BUczpvf5j3Of1vP8=",
+              "dev": true,
+              "requires": {
+                "lodash._baseflatten": "^3.0.0",
+                "lodash._baseuniq": "^3.0.0",
+                "lodash.restparam": "^3.0.0"
+              }
+            }
+          }
+        },
+        "ampersand-sync": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/ampersand-sync/-/ampersand-sync-4.0.3.tgz",
+          "integrity": "sha1-wlXWBYhZUxRyEJ+KULocCtnY1yU=",
+          "dev": true,
+          "requires": {
+            "ampersand-version": "^1.0.0",
+            "lodash.assign": "^3.0.0",
+            "lodash.defaults": "^3.1.0",
+            "lodash.includes": "^3.1.0",
+            "lodash.result": "^3.0.0",
+            "media-type": "0.3.0",
+            "qs": "^4.0.0",
+            "request": "^2.55.0",
+            "xhr": "^2.0.5"
+          },
+          "dependencies": {
+            "lodash.assign": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+              "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
+              "dev": true,
+              "requires": {
+                "lodash._baseassign": "^3.0.0",
+                "lodash._createassigner": "^3.0.0",
+                "lodash.keys": "^3.0.0"
+              }
+            },
+            "lodash.defaults": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
+              "integrity": "sha1-xzCLGNv4vJNy1wGnNJPGEZK9Liw=",
+              "dev": true,
+              "requires": {
+                "lodash.assign": "^3.0.0",
+                "lodash.restparam": "^3.0.0"
+              }
+            },
+            "lodash.includes": {
+              "version": "3.1.3",
+              "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-3.1.3.tgz",
+              "integrity": "sha1-wyLQScJ4krKaAbmVk25ZU4HrvBc=",
+              "dev": true,
+              "requires": {
+                "lodash._baseindexof": "^3.0.0",
+                "lodash._basevalues": "^3.0.0",
+                "lodash._isiterateecall": "^3.0.0",
+                "lodash.isarray": "^3.0.0",
+                "lodash.isstring": "^3.0.0",
+                "lodash.keys": "^3.0.0"
+              }
+            },
+            "lodash.isstring": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-3.0.1.tgz",
+              "integrity": "sha1-QWOJROoELvZ61nwpOqVB0/PW5Tw=",
+              "dev": true
+            }
+          }
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -16354,6 +16762,15 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
+          }
+        },
+        "lodash.escape": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+          "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+          "dev": true,
+          "requires": {
+            "lodash._root": "^3.0.0"
           }
         },
         "lodash.filter": {
@@ -16368,17 +16785,226 @@
           "integrity": "sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E=",
           "dev": true
         },
+        "lodash.isarray": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+          "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+          "dev": true
+        },
+        "lodash.isempty": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-3.0.4.tgz",
+          "integrity": "sha1-O8Vb+BHW0jLV4zVM4shkR6IPGtU=",
+          "dev": true,
+          "requires": {
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0",
+            "lodash.isfunction": "^3.0.0",
+            "lodash.isstring": "^3.0.0",
+            "lodash.keys": "^3.0.0"
+          },
+          "dependencies": {
+            "lodash.isstring": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-3.0.1.tgz",
+              "integrity": "sha1-QWOJROoELvZ61nwpOqVB0/PW5Tw=",
+              "dev": true
+            }
+          }
+        },
+        "lodash.isequal": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-3.0.4.tgz",
+          "integrity": "sha1-HDXrO27wzR/1F0Pj6jz3/f/ay2Q=",
+          "dev": true,
+          "requires": {
+            "lodash._baseisequal": "^3.0.0",
+            "lodash._bindcallback": "^3.0.0"
+          }
+        },
+        "lodash.keys": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+          "dev": true,
+          "requires": {
+            "lodash._getnative": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0"
+          }
+        },
+        "lodash.some": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-3.2.3.tgz",
+          "integrity": "sha1-djN9pP4E8NMvEMk3ha8PYFv+Lq8=",
+          "dev": true,
+          "requires": {
+            "lodash._basecallback": "^3.0.0",
+            "lodash._baseeach": "^3.0.0",
+            "lodash._isiterateecall": "^3.0.0",
+            "lodash.isarray": "^3.0.0",
+            "lodash.keys": "^3.0.0"
+          }
+        },
+        "lodash.sortby": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-3.1.5.tgz",
+          "integrity": "sha1-mEA6z3X++yQGk4MfS8DZUflHAbg=",
+          "dev": true,
+          "requires": {
+            "lodash._basecallback": "^3.0.0",
+            "lodash._basecompareascending": "^3.0.0",
+            "lodash._baseeach": "^3.0.0",
+            "lodash._basesortby": "^3.0.0",
+            "lodash._isiterateecall": "^3.0.0",
+            "lodash.isarray": "^3.0.0",
+            "lodash.keys": "^3.0.0"
+          }
+        },
         "lodash.union": {
           "version": "4.6.0",
           "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
           "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
           "dev": true
         },
+        "lodash.without": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-3.2.1.tgz",
+          "integrity": "sha1-1pYUs1EuUilLarq3gufKllOM6BY=",
+          "dev": true,
+          "requires": {
+            "lodash._basedifference": "^3.0.0",
+            "lodash.restparam": "^3.0.0"
+          }
+        },
+        "mongodb-connection-model": {
+          "version": "13.1.5",
+          "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-13.1.5.tgz",
+          "integrity": "sha512-nhRdxULysugf868UWwpH3C8b27zJRmYbRSqkHuJgvbJrauojMTuE3jIilxvr1EAFBmZgrO4Muu/JxvAQ2ekwMQ==",
+          "dev": true,
+          "requires": {
+            "ampersand-model": "^8.0.0",
+            "ampersand-rest-collection": "^6.0.0",
+            "async": "^2.1.5",
+            "backoff": "^2.4.1",
+            "debug": "^2.6.0",
+            "kerberos": "^1.1.2",
+            "lodash.assign": "^4.2.0",
+            "lodash.clone": "^4.5.0",
+            "lodash.defaults": "^4.2.0",
+            "lodash.includes": "^4.3.0",
+            "lodash.isfunction": "^3.0.8",
+            "lodash.isstring": "^4.0.1",
+            "lodash.omit": "^4.5.0",
+            "mongodb": "^3.2.2",
+            "mongodb-core": "^3.2.2",
+            "mongodb-url": "^3.0.2",
+            "raf": "^3.4.1",
+            "ssh2": "^0.5.4",
+            "storage-mixin": "^2.0.0"
+          }
+        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
+        },
+        "qs": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
+          "integrity": "sha1-wx2bdOwn33XlQ6hseHKO2NRiNgc=",
+          "dev": true
+        },
+        "storage-mixin": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/storage-mixin/-/storage-mixin-2.0.0.tgz",
+          "integrity": "sha512-fdVUPiLHpRGfimbp9oll2RBo0eDbag86neD6xdYOsb1C0Bn6cSQ1usAP314w4ARHpdlsH9337Q9ZgjNEPPdvjw==",
+          "dev": true,
+          "requires": {
+            "ampersand-model": "^6.0.2",
+            "ampersand-rest-collection": "^5.0.0",
+            "ampersand-sync": "^4.0.3",
+            "async": "^1.5.0",
+            "debug": "^4.1.0",
+            "keytar": "^4.3.0",
+            "localforage": "^1.3.0",
+            "lodash": "^4.13.1",
+            "rimraf": "^2.4.4",
+            "write-file-atomic": "^1.1.4"
+          },
+          "dependencies": {
+            "ampersand-model": {
+              "version": "6.0.3",
+              "resolved": "https://registry.npmjs.org/ampersand-model/-/ampersand-model-6.0.3.tgz",
+              "integrity": "sha1-x+zlpnFVFT4TxyR1rPF4szhKVXw=",
+              "dev": true,
+              "requires": {
+                "ampersand-state": "^4.6.0",
+                "ampersand-sync": "^4.0.3",
+                "ampersand-version": "^1.0.2",
+                "lodash.assign": "^3.2.0",
+                "lodash.clone": "^3.0.3",
+                "lodash.isobject": "^3.0.2",
+                "lodash.result": "^3.1.2"
+              }
+            },
+            "ampersand-rest-collection": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/ampersand-rest-collection/-/ampersand-rest-collection-5.0.0.tgz",
+              "integrity": "sha1-GyZOcMXt2xborMt3Hwwgi7c0eos=",
+              "dev": true,
+              "requires": {
+                "ampersand-collection": "^1.4.5",
+                "ampersand-collection-lodash-mixin": "^2.0.0",
+                "ampersand-collection-rest-mixin": "^5.0.0",
+                "ampersand-version": "^1.0.2"
+              }
+            },
+            "async": {
+              "version": "1.5.2",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+              "dev": true
+            },
+            "debug": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+              "dev": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "lodash.assign": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+              "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
+              "dev": true,
+              "requires": {
+                "lodash._baseassign": "^3.0.0",
+                "lodash._createassigner": "^3.0.0",
+                "lodash.keys": "^3.0.0"
+              }
+            },
+            "lodash.clone": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-3.0.3.tgz",
+              "integrity": "sha1-hGiMc9MrWpDKJWFpY/GJJSqZcEM=",
+              "dev": true,
+              "requires": {
+                "lodash._baseclone": "^3.0.0",
+                "lodash._bindcallback": "^3.0.0",
+                "lodash._isiterateecall": "^3.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+              "dev": true
+            }
+          }
         }
       }
     },
@@ -16437,7 +17063,7 @@
         "mongodb": "^3.1.9",
         "mongodb-js-errors": "^0.4.0",
         "mongodb-ns": "^2.0.0",
-        "triejs": "github:rueckstiess/triejs#dd30f999a9a98420e1de8e2b2ff2e6ab742ce4a5"
+        "triejs": "github:rueckstiess/triejs"
       },
       "dependencies": {
         "ampersand-class-extend": {
@@ -16872,7 +17498,7 @@
         "async": "^2.5.0",
         "bugsnag-js": "^3.2.0",
         "caller-id": "^0.1.0",
-        "debug": "github:mongodb-js/debug#c27b72464b1cde274f580d6932ee0c4b2bf01fa9",
+        "debug": "github:mongodb-js/debug#v2.2.3",
         "lodash": "^4.13.1",
         "mongodb-ns": "^2.0.0",
         "mongodb-redact": "0.1.0",
@@ -16932,7 +17558,7 @@
         "lodash.defaults": "^4.2.0",
         "lodash.uniq": "^4.5.0",
         "minimist": "^1.2.0",
-        "pre-commit": "github:mongodb-js/pre-commit#f4158768a7ef58b46808cc09a6f6a0994c0baa67",
+        "pre-commit": "github:mongodb-js/pre-commit",
         "precinct": "^6.1.0"
       },
       "dependencies": {
@@ -17247,7 +17873,7 @@
       "integrity": "sha512-zVXp9j5C14XDW2UBhmZh0N7ENypza4AVupN6zw0P1pn3kFZM9Lnmy6/JuVp9rl4vwOcK1FOFIN5JLD1/CleX9w==",
       "requires": {
         "bson": "^1.0.9",
-        "context-eval": "github:durran/context-eval#8900e57d1e9995f641ee601761672d1f9c5c726d",
+        "context-eval": "github:durran/context-eval",
         "debug": "^3.1.0",
         "is-json": "^2.0.1",
         "javascript-stringify": "^1.6.0",
@@ -19688,7 +20314,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "mongodb-ace-mode": "^0.3.0",
     "mongodb-ace-theme": "^0.0.1",
     "mongodb-connection-model": "^13.0.1",
-    "mongodb-data-service": "^12.4.17",
+    "mongodb-data-service": "^13.0.0",
     "mongodb-js-metrics": "^4.2.0",
     "mongodb-js-precommit": "^2.0.0",
     "mongodb-reflux-store": "0.0.1",

--- a/src/assets/less/bootstrap.less
+++ b/src/assets/less/bootstrap.less
@@ -16,26 +16,26 @@
 @import "~bootstrap/less/forms.less";
 
 // Components
-// @import "~bootstrap/less/component-animations.less";
+@import "~bootstrap/less/component-animations.less";
 @import "~bootstrap/less/dropdowns.less";
-// @import "~bootstrap/less/input-groups.less";
-// @import "~bootstrap/less/navs.less";
-// @import "~bootstrap/less/navbar.less";
-// @import "~bootstrap/less/breadcrumbs.less";
-// @import "~bootstrap/less/pagination.less";
-// @import "~bootstrap/less/pager.less";
-// @import "~bootstrap/less/labels.less";
-// @import "~bootstrap/less/badges.less";
-// @import "~bootstrap/less/jumbotron.less";
-// @import "~bootstrap/less/thumbnails.less";
-// @import "~bootstrap/less/alerts.less";
-// @import "~bootstrap/less/progress-bars.less";
-// @import "~bootstrap/less/media.less";
-// @import "~bootstrap/less/list-group.less";
-// @import "~bootstrap/less/panels.less";
-// @import "~bootstrap/less/responsive-embed.less";
-// @import "~bootstrap/less/wells.less";
-// @import "~bootstrap/less/close.less";
+@import "~bootstrap/less/input-groups.less";
+@import "~bootstrap/less/navs.less";
+@import "~bootstrap/less/navbar.less";
+@import "~bootstrap/less/breadcrumbs.less";
+@import "~bootstrap/less/pagination.less";
+@import "~bootstrap/less/pager.less";
+@import "~bootstrap/less/labels.less";
+@import "~bootstrap/less/badges.less";
+@import "~bootstrap/less/jumbotron.less";
+@import "~bootstrap/less/thumbnails.less";
+@import "~bootstrap/less/alerts.less";
+@import "~bootstrap/less/progress-bars.less";
+@import "~bootstrap/less/media.less";
+@import "~bootstrap/less/list-group.less";
+@import "~bootstrap/less/panels.less";
+@import "~bootstrap/less/responsive-embed.less";
+@import "~bootstrap/less/wells.less";
+@import "~bootstrap/less/close.less";
 
 // Components w/ JavaScript
 @import "~bootstrap/less/modals.less";

--- a/src/assets/less/compass/components/_index.less
+++ b/src/assets/less/compass/components/_index.less
@@ -2,6 +2,7 @@
 
 @import "~less/compass/components/_buttons";
 @import "~less/compass/components/_caret";
+@import "~less/compass/components/_modal-status-message";
 @import "~less/compass/components/_message-background";
 @import "~less/compass/components/_mms-icons";
 @import "~less/compass/components/_react-select";

--- a/src/assets/less/compass/components/_modal-status-message.less
+++ b/src/assets/less/compass/components/_modal-status-message.less
@@ -1,0 +1,82 @@
+.modal-status-error {
+  background: #ef4c4c;
+  color: #fff;
+  margin-bottom: 10px;
+  overflow: auto;
+
+  .panel-body {
+    padding: 8px;
+
+    .row {
+      margin-left: -7px;
+      margin-right: -8px;
+
+      .col-md-1 {
+        width: 8%;
+      }
+
+      .col-md-11 {
+        width: 90%;
+      }
+    }
+  }
+
+  .modal-status-error-icon {
+    font-size: 20px;
+    font-weight: bold;
+    margin-bottom: 0px;
+    margin-left: 4px;
+    vertical-align: middle;
+  }
+
+  .modal-status-error-message {
+    display: inline-block;
+    font-family: sans-serif;
+    font-weight: bold;
+    font-size: 15px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    vertical-align: middle;
+  }
+}
+
+.modal-status-in-progress {
+  background: rgb(73, 180, 230);
+  color: #fff;
+  margin-bottom: 10px;
+
+  .panel-body {
+    padding: 8px;
+
+    .row {
+      margin-left: -7px;
+      margin-right: -8px;
+
+      .col-md-1 {
+        width: 8%;
+      }
+
+      .col-md-11 {
+        width: 90%;
+      }
+    }
+  }
+
+  .modal-status-in-progress-icon {
+    font-size: 20px;
+    font-weight: bold;
+    margin-bottom: 0px;
+    margin-left: 8px;
+    vertical-align: middle;
+  }
+
+  .modal-status-in-progress-message {
+    display: inline-block;
+    font-family: sans-serif;
+    font-weight: bold;
+    font-size: 15px;
+    margin-bottom: 0px;
+    margin-left: 12px;
+    vertical-align: middle;
+  }
+}

--- a/src/components/aggregations/aggregations.jsx
+++ b/src/components/aggregations/aggregations.jsx
@@ -23,7 +23,12 @@ import { exportToLanguage } from 'modules/export-to-language';
 import { openLink } from 'modules/link';
 import { toggleOverview } from 'modules/is-overview-on';
 import { toggleFullscreen } from 'modules/is-fullscreen-on';
-import { deletePipeline, newPipeline, clonePipeline } from 'modules';
+import {
+  deletePipeline,
+  newPipeline,
+  clonePipeline,
+  openCreateView
+} from 'modules';
 import {
   runStage,
   runOutStage,
@@ -58,8 +63,7 @@ import {
   closeImport,
   changeText,
   createNew,
-  confirmNew,
-  openCreateView
+  confirmNew
 } from 'modules/import-pipeline';
 
 import {

--- a/src/components/aggregations/aggregations.jsx
+++ b/src/components/aggregations/aggregations.jsx
@@ -58,7 +58,8 @@ import {
   closeImport,
   changeText,
   createNew,
-  confirmNew
+  confirmNew,
+  openCreateView
 } from 'modules/import-pipeline';
 
 import {
@@ -201,7 +202,8 @@ const MappedAggregations = connect(
     savingPipelineCancel,
     savingPipelineOpen,
     projectionsChanged,
-    newPipelineFromPaste
+    newPipelineFromPaste,
+    openCreateView
   }
 )(Aggregations);
 

--- a/src/components/create-view-modal/create-view-modal.jsx
+++ b/src/components/create-view-modal/create-view-modal.jsx
@@ -1,7 +1,6 @@
 import { TextButton } from 'hadron-react-buttons';
 import React, { PureComponent } from 'react';
 import { Modal } from 'react-bootstrap';
-import classnames from 'classnames';
 import PropTypes from 'prop-types';
 
 import { connect } from 'react-redux';
@@ -63,7 +62,7 @@ class CreateViewModal extends PureComponent {
           <Modal.Title>Create a View</Modal.Title>
         </Modal.Header>
 
-        <Modal.Body className={classnames(styles['create-view-modal-body'])}>
+        <Modal.Body className={styles['create-view-modal-body']}>
           <form
             name="create-view-modal-form"
             onSubmit={this.onFormSubmit}
@@ -92,7 +91,7 @@ class CreateViewModal extends PureComponent {
         </Modal.Body>
 
         <Modal.Footer
-          className={classnames(styles['create-view-modal-footer'])}>
+          className={styles['create-view-modal-footer']}>
           <TextButton
             className="btn btn-default btn-sm"
             dataTestId="cancel-create-view-button"

--- a/src/components/create-view-modal/create-view-modal.jsx
+++ b/src/components/create-view-modal/create-view-modal.jsx
@@ -71,7 +71,6 @@ class CreateViewModal extends PureComponent {
             <ModalInput
               autoFocus
               id="create-view-name"
-              name="View Name"
               value={this.props.name}
               onChangeHandler={this.onNameChange}
             />
@@ -103,7 +102,7 @@ class CreateViewModal extends PureComponent {
           <TextButton
             className="btn btn-primary btn-sm"
             dataTestId="create-view-button"
-            text="Create View"
+            text="Create"
             clickHandler={this.props.createView}
           />
         </Modal.Footer>

--- a/src/components/create-view-modal/create-view-modal.jsx
+++ b/src/components/create-view-modal/create-view-modal.jsx
@@ -1,0 +1,145 @@
+import { TextButton } from 'hadron-react-buttons';
+import React, { PureComponent } from 'react';
+import { Modal } from 'react-bootstrap';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+
+import { connect } from 'react-redux';
+
+import { ModalInput, ModalStatusMessage } from 'hadron-react-components';
+
+import { createView } from 'modules/create-view';
+import { changeViewName } from 'modules/create-view/name';
+import { toggleIsVisible } from 'modules/create-view/is-visible';
+
+import styles from './create-view-modal.less';
+
+class CreateViewModal extends PureComponent {
+  static displayName = 'CreateViewModalComponent';
+
+  static propTypes = {
+    createView: PropTypes.func.isRequired,
+
+    isVisible: PropTypes.bool.isRequired,
+    toggleIsVisible: PropTypes.func.isRequired,
+
+    name: PropTypes.string.isRequired,
+    changeViewName: PropTypes.func.isRequired,
+
+    source: PropTypes.string.isRequired,
+    pipeline: PropTypes.array.isRequired,
+    isRunning: PropTypes.bool.isRequired,
+    error: PropTypes.object
+  };
+
+  onNameChange = (evt) => {
+    this.props.changeViewName(evt.target.value);
+  };
+
+  onFormSubmit = (evt) => {
+    evt.preventDefault();
+    evt.stopPropagation();
+    this.props.createView();
+  };
+
+  onCancel = () => {
+    this.props.toggleIsVisible(false);
+  };
+
+  /**
+   * Render the save pipeline component.
+   *
+   * @returns {Component} The component.
+   */
+  render() {
+    return (
+      <Modal
+        show={this.props.isVisible}
+        backdrop="static"
+        bsSize="small"
+        onHide={this.onCancel}
+        dialogClassName={styles['create-view-modal']}>
+        <Modal.Header>
+          <Modal.Title>Create a View</Modal.Title>
+        </Modal.Header>
+
+        <Modal.Body className={classnames(styles['create-view-modal-body'])}>
+          <form
+            name="create-view-modal-form"
+            onSubmit={this.onFormSubmit}
+            data-test-id="create-view-modal">
+            <ModalInput
+              autoFocus
+              id="create-view-name"
+              name="View Name"
+              value={this.props.name}
+              onChangeHandler={this.onNameChange}
+            />
+            {this.props.error ? (
+              <ModalStatusMessage
+                icon="times"
+                message={this.props.error.message}
+                type="error"
+              />
+            ) : null}
+            {this.props.isRunning ? (
+              <ModalStatusMessage
+                icon="spinner"
+                message="Create in Progress"
+                type="in-progress"
+              />
+            ) : null}
+          </form>
+        </Modal.Body>
+
+        <Modal.Footer
+          className={classnames(styles['create-view-modal-footer'])}>
+          <TextButton
+            className="btn btn-default btn-sm"
+            dataTestId="cancel-create-view-button"
+            text="Cancel"
+            clickHandler={this.onCancel}
+          />
+          <TextButton
+            className="btn btn-primary btn-sm"
+            dataTestId="create-view-button"
+            text="Create View"
+            clickHandler={this.props.createView}
+          />
+        </Modal.Footer>
+      </Modal>
+    );
+  }
+}
+
+/**
+ * Map the store state to properties to pass to the components.
+ *
+ * @param {Object} state - The store state.
+ *
+ * @returns {Object} The mapped properties.
+ */
+const mapStateToProps = (state) => ({
+  isRunning: state.isRunning,
+  isVisible: state.isVisible,
+  name: state.name,
+  error: state.error,
+  source: state.source,
+  pipeline: state.pipeline
+});
+
+/**
+ * Connect the redux store to the component.
+ * (dispatch)
+ */
+const MappedCreateViewModal = connect(
+  mapStateToProps,
+  {
+    createView,
+    changeViewName,
+    toggleIsVisible
+  }
+)(CreateViewModal);
+
+export default MappedCreateViewModal;
+export { CreateViewModal };

--- a/src/components/create-view-modal/create-view-modal.less
+++ b/src/components/create-view-modal/create-view-modal.less
@@ -1,0 +1,10 @@
+@import (reference) "~less/compass/_theme.less";
+
+.create-view-modal {
+  &-header, &-body {
+    border-bottom: 0;
+  }
+  &-footer {
+    border-top: 0;
+  }
+}

--- a/src/components/create-view-modal/index.js
+++ b/src/components/create-view-modal/index.js
@@ -1,0 +1,3 @@
+import MappedCreateViewModal, { CreateViewModal } from './create-view-modal';
+export default MappedCreateViewModal;
+export { CreateViewModal };

--- a/src/components/create-view-plugin.jsx
+++ b/src/components/create-view-plugin.jsx
@@ -1,0 +1,23 @@
+import React, { Component } from 'react';
+import { Provider } from 'react-redux';
+import CreateViewModal from 'components/create-view-modal';
+import store from 'stores/create-view';
+
+class CreateViewPlugin extends Component {
+  static displayName = 'CreateViewPlugin';
+
+  /**
+   * Connect the Plugin to the store and render.
+   *
+   * @returns {React.Component} The rendered component.
+   */
+  render() {
+    return (
+      <Provider store={store}>
+        <CreateViewModal />
+      </Provider>
+    );
+  }
+}
+
+export default CreateViewPlugin;

--- a/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
+++ b/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
@@ -8,11 +8,10 @@ import OverviewToggler from './overview-toggler';
 import CollationCollapser from './collation-collapser';
 import semver from 'semver';
 
-const VIEWS_MIN_SERVER_VERSION = '3.4.0';
-
 import {
   TOOLTIP_EXPORT_TO_LANGUAGE,
-  TOOLTIP_OPEN_SAVED_PIPELINES
+  TOOLTIP_OPEN_SAVED_PIPELINES,
+  VIEWS_MIN_SERVER_VERSION
 } from '../../constants';
 
 import styles from './pipeline-builder-toolbar.less';
@@ -158,16 +157,70 @@ class PipelineBuilderToolbar extends PureComponent {
     return children;
   }
 
-  /**
-   * Renders the pipeline builder toolbar.
-   *
-   * @returns {React.Component} The component.
-   */
-  render() {
+  renderSavedPipelineListToggler() {
     const clickHandler = this.props.savedPipeline.isListVisible
       ? this.handleSavedPipelinesClose
       : this.handleSavedPipelinesOpen;
 
+    return (
+      <span
+        data-tip={TOOLTIP_OPEN_SAVED_PIPELINES}
+        data-for="open-saved-pipelines"
+        data-place="top"
+        data-html="true">
+        <IconButton
+          title="Toggle Saved Pipelines"
+          className={classnames(
+            'btn',
+            'btn-xs',
+            'btn-default',
+            styles['pipeline-builder-toolbar-open-saved-pipelines-button']
+          )}
+          iconClassName="fa fa-folder-open-o"
+          clickHandler={clickHandler}
+        />
+        <Tooltip id="open-saved-pipelines" />
+      </span>
+    );
+  }
+
+  renderNewPipelineActionsItem() {
+    return (
+      <div>
+        <Dropdown id="new-pipeline-actions" className="btn-group">
+          <Button
+            variant="default"
+            className={classnames(
+              'btn-xs',
+              styles['pipeline-builder-toolbar-new-button']
+            )}
+            onClick={this.props.newPipeline}>
+            <i className="fa fa-plus-circle" />
+          </Button>
+          <Dropdown.Toggle className="btn-default btn-xs btn" />
+
+          <Dropdown.Menu>
+            <MenuItem onClick={this.props.newPipelineFromText}>
+              New Pipeline From Text
+            </MenuItem>
+          </Dropdown.Menu>
+        </Dropdown>
+      </div>
+    );
+  }
+
+  renderSavedPipelineNameItem() {
+    return (
+      <div className={styles['pipeline-builder-toolbar-add-wrapper']}>
+        <div className={styles['pipeline-builder-toolbar-name']}>
+          {this.props.name || 'Untitled'}
+        </div>
+        {this.renderIsModifiedIndicator()}
+      </div>
+    );
+  }
+
+  renderSavePipelineActionsItem() {
     const savePipelineClassName = classnames({
       btn: true,
       'btn-xs': true,
@@ -176,89 +229,62 @@ class PipelineBuilderToolbar extends PureComponent {
     });
 
     return (
-      <div className={classnames(styles['pipeline-builder-toolbar'])}>
+      <div>
+        <Dropdown id="save-pipeline-actions">
+          <Button
+            className={savePipelineClassName}
+            variant="primary"
+            onClick={this.onSaveClicked.bind(this)}>
+            Save
+          </Button>
+
+          <Dropdown.Toggle className="btn-xs btn btn-primary" />
+          <Dropdown.Menu>{this.renderSaveDropdownMenu()}</Dropdown.Menu>
+        </Dropdown>
+      </div>
+    );
+  }
+
+  renderExportToLanguageItem() {
+    return (
+      <div
+        className={styles['pipeline-builder-toolbar-export-to-language']}
+        data-tip={TOOLTIP_EXPORT_TO_LANGUAGE}
+        data-for="export-to-language"
+        data-place="top"
+        data-html="true">
+        <IconButton
+          className="btn btn-xs btn-default"
+          iconClassName={classnames(styles['export-icon'])}
+          clickHandler={this.props.exportToLanguage}
+          title="Export To Language"
+        />
+        <Tooltip id="export-to-language" />
+      </div>
+    );
+  }
+
+  /**
+   * Renders the pipeline builder toolbar.
+   *
+   * @returns {React.Component} The component.
+   */
+  render() {
+    return (
+      <div className={styles['pipeline-builder-toolbar']}>
         <OverviewToggler
           isOverviewOn={this.props.isOverviewOn}
           toggleOverview={this.props.toggleOverview}
         />
-        <span
-          data-tip={TOOLTIP_OPEN_SAVED_PIPELINES}
-          data-for="open-saved-pipelines"
-          data-place="top"
-          data-html="true">
-          <IconButton
-            title="Toggle Saved Pipelines"
-            className={classnames(
-              'btn',
-              'btn-xs',
-              'btn-default',
-              styles['pipeline-builder-toolbar-open-saved-pipelines-button']
-            )}
-            iconClassName="fa fa-folder-open-o"
-            clickHandler={clickHandler}
-          />
-          <Tooltip id="open-saved-pipelines" />
-        </span>
-        <div>
-          <Dropdown id="new-pipeline-actions" className="btn-group">
-            <Button
-              variant="default"
-              className={classnames(
-                'btn-xs',
-                styles['pipeline-builder-toolbar-new-button']
-              )}
-              onClick={this.props.newPipeline}>
-              <i className="fa fa-plus-circle" />
-            </Button>
-            <Dropdown.Toggle className="btn-default btn-xs btn" />
-
-            <Dropdown.Menu>
-              <MenuItem onClick={this.props.newPipelineFromText}>
-                New Pipeline From Text
-              </MenuItem>
-            </Dropdown.Menu>
-          </Dropdown>
-        </div>
+        {this.renderSavedPipelineListToggler()}
+        {this.renderNewPipelineActionsItem()}
         <CollationCollapser
           isCollationExpanded={this.props.isCollationExpanded}
           collationCollapseToggled={this.props.collationCollapseToggled}
         />
-        <div
-          className={classnames(
-            styles['pipeline-builder-toolbar-add-wrapper']
-          )}>
-          <div className={styles['pipeline-builder-toolbar-name']}>
-            {this.props.name || 'Untitled'}
-          </div>
-          {this.renderIsModifiedIndicator()}
-        </div>
-        <div>
-          <Dropdown id="save-pipeline-actions">
-            <Button
-              className={savePipelineClassName}
-              variant="primary"
-              onClick={this.onSaveClicked.bind(this)}>
-              Save
-            </Button>
-
-            <Dropdown.Toggle className="btn-xs btn btn-primary" />
-            <Dropdown.Menu>{this.renderSaveDropdownMenu()}</Dropdown.Menu>
-          </Dropdown>
-        </div>
-        <div
-          className={styles['pipeline-builder-toolbar-export-to-language']}
-          data-tip={TOOLTIP_EXPORT_TO_LANGUAGE}
-          data-for="export-to-language"
-          data-place="top"
-          data-html="true">
-          <IconButton
-            className="btn btn-xs btn-default"
-            iconClassName={classnames(styles['export-icon'])}
-            clickHandler={this.props.exportToLanguage}
-            title="Export To Language"
-          />
-          <Tooltip id="export-to-language" />
-        </div>
+        {this.renderSavedPipelineNameItem()}
+        {this.renderSavePipelineActionsItem()}
+        {this.renderExportToLanguageItem()}
       </div>
     );
   }

--- a/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
+++ b/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
@@ -42,6 +42,7 @@ class PipelineBuilderToolbar extends PureComponent {
     toggleOverview: PropTypes.func.isRequired,
 
     serverVersion: PropTypes.string.isRequired,
+    openCreateView: PropTypes.func.isRequired,
 
     /**
      * Saved Pipelines
@@ -93,8 +94,6 @@ class PipelineBuilderToolbar extends PureComponent {
     }
     this.props.savingPipelineOpen({ name: this.props.name, isSaveAs: true });
   };
-
-  onSaveAsView = () => {};
 
   handleSavedPipelinesOpen = () => {
     this.props.getSavedPipelines();
@@ -151,7 +150,7 @@ class PipelineBuilderToolbar extends PureComponent {
 
     if (serverViewsAvailable) {
       children.push(
-        <MenuItem key="create-a-view" onClick={this.onSaveAsView.bind(this)}>
+        <MenuItem key="create-a-view" onClick={this.props.openCreateView}>
           Create a View
         </MenuItem>
       );

--- a/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
+++ b/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
@@ -94,7 +94,7 @@ class PipelineBuilderToolbar extends PureComponent {
     this.props.savingPipelineOpen({ name: this.props.name, isSaveAs: true });
   };
 
-  onSaveAsView = () => {}
+  onSaveAsView = () => {};
 
   handleSavedPipelinesOpen = () => {
     this.props.getSavedPipelines();
@@ -137,16 +137,21 @@ class PipelineBuilderToolbar extends PureComponent {
 
   renderSaveDropdownMenu() {
     const children = [
-      (<MenuItem onClick={this.onSaveAsClicked.bind(this)}>
+      <MenuItem
+        key="save-pipeline-as"
+        onClick={this.onSaveAsClicked.bind(this)}>
         Save pipeline as&hellip;
-      </MenuItem>)
+      </MenuItem>
     ];
 
-    const serverViewsAvailable = semver.gte(this.props.serverVersion, VIEWS_MIN_SERVER_VERSION);
+    const serverViewsAvailable = semver.gte(
+      this.props.serverVersion,
+      VIEWS_MIN_SERVER_VERSION
+    );
 
     if (serverViewsAvailable) {
       children.push(
-        <MenuItem onClick={this.onSaveAsView.bind(this)}>
+        <MenuItem key="create-a-view" onClick={this.onSaveAsView.bind(this)}>
           Create a View
         </MenuItem>
       );
@@ -238,9 +243,7 @@ class PipelineBuilderToolbar extends PureComponent {
             </Button>
 
             <Dropdown.Toggle className="btn-xs btn btn-primary" />
-            <Dropdown.Menu>
-              {this.renderSaveDropdownMenu()}
-            </Dropdown.Menu>
+            <Dropdown.Menu>{this.renderSaveDropdownMenu()}</Dropdown.Menu>
           </Dropdown>
         </div>
         <div

--- a/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
+++ b/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
@@ -150,7 +150,7 @@ class PipelineBuilderToolbar extends PureComponent {
     if (serverViewsAvailable) {
       children.push(
         <MenuItem key="create-a-view" onClick={this.props.openCreateView}>
-          Create a View
+          Create a view
         </MenuItem>
       );
     }

--- a/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
+++ b/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
@@ -6,6 +6,9 @@ import { Tooltip } from 'hadron-react-components';
 import { Dropdown, MenuItem, Button } from 'react-bootstrap';
 import OverviewToggler from './overview-toggler';
 import CollationCollapser from './collation-collapser';
+import semver from 'semver';
+
+const VIEWS_MIN_SERVER_VERSION = '3.4.0';
 
 import {
   TOOLTIP_EXPORT_TO_LANGUAGE,
@@ -37,6 +40,8 @@ class PipelineBuilderToolbar extends PureComponent {
 
     isOverviewOn: PropTypes.bool.isRequired,
     toggleOverview: PropTypes.func.isRequired,
+
+    serverVersion: PropTypes.string.isRequired,
 
     /**
      * Saved Pipelines
@@ -89,6 +94,8 @@ class PipelineBuilderToolbar extends PureComponent {
     this.props.savingPipelineOpen({ name: this.props.name, isSaveAs: true });
   };
 
+  onSaveAsView = () => {}
+
   handleSavedPipelinesOpen = () => {
     this.props.getSavedPipelines();
     this.props.savedPipelinesListToggle(1);
@@ -126,6 +133,25 @@ class PipelineBuilderToolbar extends PureComponent {
         - <span>Modified</span>
       </div>
     );
+  }
+
+  renderSaveDropdownMenu() {
+    const children = [
+      (<MenuItem onClick={this.onSaveAsClicked.bind(this)}>
+        Save pipeline as&hellip;
+      </MenuItem>)
+    ];
+
+    const serverViewsAvailable = semver.gte(this.props.serverVersion, VIEWS_MIN_SERVER_VERSION);
+
+    if (serverViewsAvailable) {
+      children.push(
+        <MenuItem onClick={this.onSaveAsView.bind(this)}>
+          Create a View
+        </MenuItem>
+      );
+    }
+    return children;
   }
 
   /**
@@ -212,11 +238,8 @@ class PipelineBuilderToolbar extends PureComponent {
             </Button>
 
             <Dropdown.Toggle className="btn-xs btn btn-primary" />
-
             <Dropdown.Menu>
-              <MenuItem onClick={this.onSaveAsClicked.bind(this)}>
-                Save pipeline as&hellip;
-              </MenuItem>
+              {this.renderSaveDropdownMenu()}
             </Dropdown.Menu>
           </Dropdown>
         </div>

--- a/src/components/pipeline-toolbar/pipeline-builder-toolbar.spec.js
+++ b/src/components/pipeline-toolbar/pipeline-builder-toolbar.spec.js
@@ -49,6 +49,7 @@ describe('PipelineBuilderToolbar [Component]', () => {
         setIsModified={setIsModifiedSpy}
         collationCollapseToggled={collationCollapseSpy}
         exportToLanguage={exportToLanguageSpy}
+        serverVersion="4.0.0"
       />
     );
   });

--- a/src/components/pipeline-toolbar/pipeline-preview-toolbar.jsx
+++ b/src/components/pipeline-toolbar/pipeline-preview-toolbar.jsx
@@ -1,12 +1,18 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
+
 import Switch from 'react-ios-switch';
 import { Tooltip } from 'hadron-react-components';
 import { IconButton } from 'hadron-react-buttons';
 
 import styles from './pipeline-preview-toolbar.less';
 import { TOOLTIP_PREVIEW_MODE, TOOLTIP_SAMPLING_MODE } from '../../constants';
+
+const SHARED_SWITCH_PROPS = {
+  className: styles.switch,
+  onColor: 'rgb(19, 170, 82)',
+  style: { backgroundColor: 'rgb(255,255,255)' }
+};
 
 /**
  * The pipeline preview toolbar component.
@@ -33,11 +39,9 @@ class PipelinePreviewToolbar extends PureComponent {
         data-place="top"
         data-html="true">
         <Switch
-          className={styles.switch}
           checked={this.props.isAutoPreviewing}
           onChange={this.props.toggleAutoPreview}
-          onColor="rgb(19, 170, 82)"
-          style={{ backgroundColor: 'rgb(255,255,255)' }}
+          {...SHARED_SWITCH_PROPS}
         />
         <span className={styles['toggle-auto-preview-label']}>
           Auto Preview
@@ -56,11 +60,9 @@ class PipelinePreviewToolbar extends PureComponent {
         data-place="top"
         data-html="true">
         <Switch
-          className={styles.switch}
           checked={this.props.isSampling}
           onChange={this.props.toggleSample}
-          onColor="rgb(19, 170, 82)"
-          style={{ backgroundColor: 'rgb(255,255,255)' }}
+          {...SHARED_SWITCH_PROPS}
         />
         <span className={styles['toggle-sample-label']}>Sample Mode</span>
         <Tooltip id="sampling-mode" />
@@ -90,6 +92,19 @@ class PipelinePreviewToolbar extends PureComponent {
     );
   }
 
+  renderSettingsToggle() {
+    return (
+      <div className={styles.settings}>
+        <IconButton
+          title="Settings"
+          className="btn btn-xs btn-default"
+          iconClassName="fa fa-gear"
+          clickHandler={this.props.toggleSettingsIsExpanded}
+        />
+      </div>
+    );
+  }
+
   /**
    * Renders the pipeline preview toolbar.
    *
@@ -97,18 +112,10 @@ class PipelinePreviewToolbar extends PureComponent {
    */
   render() {
     return (
-      <div className={classnames(styles['container-right'])}>
+      <div className={styles['container-right']}>
         {this.renderSampleToggle()}
         {this.renderAutoPreviewToggle()}
-
-        <div className={styles.settings}>
-          <IconButton
-            title="Settings"
-            className="btn btn-xs btn-default"
-            iconClassName="fa fa-gear"
-            clickHandler={this.props.toggleSettingsIsExpanded}
-          />
-        </div>
+        {this.renderSettingsToggle()}
         {this.renderFullscreenButton()}
       </div>
     );

--- a/src/components/pipeline-toolbar/pipeline-toolbar.jsx
+++ b/src/components/pipeline-toolbar/pipeline-toolbar.jsx
@@ -39,7 +39,8 @@ class PipelineToolbar extends PureComponent {
     isFullscreenOn: PropTypes.bool.isRequired,
     toggleFullscreen: PropTypes.func.isRequired,
     savingPipelineOpen: PropTypes.func.isRequired,
-    serverVersion: PropTypes.string.isRequired
+    serverVersion: PropTypes.string.isRequired,
+    openCreateView: PropTypes.func.isRequired
   };
 
   static defaultProps = {
@@ -79,6 +80,7 @@ class PipelineToolbar extends PureComponent {
           toggleOverview={this.props.toggleOverview}
           savingPipelineOpen={this.props.savingPipelineOpen}
           serverVersion={this.props.serverVersion}
+          openCreateView={this.props.openCreateView}
         />
         <PipelinePreviewToolbar
           toggleComments={this.props.toggleComments}

--- a/src/components/pipeline-toolbar/pipeline-toolbar.jsx
+++ b/src/components/pipeline-toolbar/pipeline-toolbar.jsx
@@ -38,7 +38,8 @@ class PipelineToolbar extends PureComponent {
     toggleSettingsIsExpanded: PropTypes.func.isRequired,
     isFullscreenOn: PropTypes.bool.isRequired,
     toggleFullscreen: PropTypes.func.isRequired,
-    savingPipelineOpen: PropTypes.func.isRequired
+    savingPipelineOpen: PropTypes.func.isRequired,
+    serverVersion: PropTypes.string.isRequired
   };
 
   static defaultProps = {
@@ -77,6 +78,7 @@ class PipelineToolbar extends PureComponent {
           isOverviewOn={this.props.isOverviewOn}
           toggleOverview={this.props.toggleOverview}
           savingPipelineOpen={this.props.savingPipelineOpen}
+          serverVersion={this.props.serverVersion}
         />
         <PipelinePreviewToolbar
           toggleComments={this.props.toggleComments}

--- a/src/components/pipeline-toolbar/pipeline-toolbar.spec.js
+++ b/src/components/pipeline-toolbar/pipeline-toolbar.spec.js
@@ -74,6 +74,7 @@ describe('PipelineToolbar [Component]', () => {
         isFullscreenOn={false}
         toggleFullscreen={toggleFullscreenSpy}
         toggleSettingsIsExpanded={toggleSettingsIsExpandedSpy}
+        serverVersion="4.0.0"
       />
     );
   });

--- a/src/components/pipeline/pipeline.jsx
+++ b/src/components/pipeline/pipeline.jsx
@@ -210,6 +210,7 @@ class Pipeline extends PureComponent {
           isFullscreenOn={this.props.isFullscreenOn}
           toggleFullscreen={this.props.toggleFullscreen}
           savingPipelineOpen={this.props.savingPipelineOpen}
+          serverVersion={this.props.serverVersion}
         />
         {this.renderCollationToolbar()}
         <Splitter isCollationExpanded={this.props.isCollationExpanded} />

--- a/src/components/pipeline/pipeline.jsx
+++ b/src/components/pipeline/pipeline.jsx
@@ -96,7 +96,8 @@ class Pipeline extends PureComponent {
     savingPipeline: PropTypes.object.isRequired,
     projections: PropTypes.array.isRequired,
     projectionsChanged: PropTypes.func.isRequired,
-    newPipelineFromPaste: PropTypes.func.isRequired
+    newPipelineFromPaste: PropTypes.func.isRequired,
+    openCreateView: PropTypes.func.isRequired
   };
 
   /**
@@ -211,6 +212,7 @@ class Pipeline extends PureComponent {
           toggleFullscreen={this.props.toggleFullscreen}
           savingPipelineOpen={this.props.savingPipelineOpen}
           serverVersion={this.props.serverVersion}
+          openCreateView={this.props.openCreateView}
         />
         {this.renderCollationToolbar()}
         <Splitter isCollationExpanded={this.props.isCollationExpanded} />

--- a/src/constants.js
+++ b/src/constants.js
@@ -30,6 +30,8 @@ export const REQUIRED_AS_FIRST_STAGE = [
   '$listSessions'
 ];
 
+export const VIEWS_MIN_SERVER_VERSION = '3.4.0';
+
 /**
  * Ops that must scan the entire results before moving to the
  * next stage.

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,10 @@
 import AggregationsPlugin from './plugin';
 import AggregationsStore from 'stores';
 import { Aggregations } from 'components/aggregations';
+
+import CreateViewPlugin from 'components/create-view-plugin';
+import CreateViewStore from 'stores/create-view';
+
 import StageEditor from 'components/stage-editor';
 
 /**
@@ -13,6 +17,14 @@ const ROLE = {
 };
 
 /**
+ * Create view modal plugin.
+ */
+const CREATE_ROLE = {
+  name: 'Create View',
+  component: CreateViewPlugin
+};
+
+/**
  * Activate all the components in the Aggregations package.
 
  * @param {Object} appRegistry - The Hadron appRegisrty to activate this plugin with.
@@ -20,6 +32,9 @@ const ROLE = {
 const activate = (appRegistry) => {
   appRegistry.registerRole('Collection.Tab', ROLE);
   appRegistry.registerStore('Aggregations.Store', AggregationsStore);
+
+  appRegistry.registerRole('Global.Modal', CREATE_ROLE);
+  appRegistry.registerStore('Aggregations.CreateViewStore', CreateViewStore);
 };
 
 /**
@@ -30,6 +45,9 @@ const activate = (appRegistry) => {
 const deactivate = (appRegistry) => {
   appRegistry.deregisterRole('Collection.Tab', ROLE);
   appRegistry.deregisterStore('Aggregations.Store');
+
+  appRegistry.deregisterRole('Global.Modal', CREATE_ROLE);
+  appRegistry.deregisterStore('Aggregations.CreateViewStore');
 };
 
 export default AggregationsPlugin;

--- a/src/modules/create-view/error.js
+++ b/src/modules/create-view/error.js
@@ -1,0 +1,57 @@
+/**
+ * The action name prefix.
+ */
+const PREFIX = 'aggregations/create-view/error';
+
+/**
+ * Handle error action name.
+ */
+export const HANDLE_ERROR = `${PREFIX}/HANDLE_ERROR`;
+
+/**
+ * Clear error action name.
+ */
+export const CLEAR_ERROR = `${PREFIX}/CLEAR_ERROR`;
+
+/**
+ * The initial state of the error.
+ */
+export const INITIAL_STATE = null;
+
+/**
+ * Reducer function for handle state changes to errors.
+ *
+ * @param {Error} state - The error state.
+ * @param {Object} action - The action.
+ *
+ * @returns {Error} The new state.
+ */
+export default function reducer(state = INITIAL_STATE, action) {
+  if (action.type === HANDLE_ERROR) {
+    return action.error;
+  } else if (action.type === CLEAR_ERROR) {
+    return null;
+  }
+  return state;
+}
+
+/**
+ * Handle error action creator.
+ *
+ * @param {Error} error - The error.
+ *
+ * @returns {Object} The action.
+ */
+export const handleError = (error) => ({
+  type: HANDLE_ERROR,
+  error: error
+});
+
+/**
+ * Clear error action creator.
+ *
+ * @returns {Object} The action.
+ */
+export const clearError = () => ({
+  type: CLEAR_ERROR
+});

--- a/src/modules/create-view/index.js
+++ b/src/modules/create-view/index.js
@@ -28,6 +28,8 @@ import error, {
 
 import { reset, RESET } from 'modules/create-view/reset';
 
+const parseNs = require('mongodb-ns');
+
 /**
  * Open action name.
  */
@@ -121,6 +123,7 @@ export const createView = () => {
 
     const viewName = state.name;
     const viewSource = state.source;
+    const { database } = parseNs(state.source);
     const viewPipeline = state.pipeline;
     const options = {};
 
@@ -134,6 +137,12 @@ export const createView = () => {
           return stopWithError(dispatch, e);
         }
         global.hadronApp.appRegistry.emit('refresh-data');
+
+        global.hadronApp.appRegistry.emit(
+          'open-namespace-in-new-tab',
+          `${database}.${viewName}`,
+          true
+        );
         dispatch(reset());
       });
     } catch (e) {

--- a/src/modules/create-view/index.js
+++ b/src/modules/create-view/index.js
@@ -33,7 +33,7 @@ import { reset, RESET } from 'modules/create-view/reset';
  */
 const OPEN = 'aggregations/create-view/OPEN';
 
-const INITIAL_STATE = {
+export const INITIAL_STATE = {
   isRunning: IS_RUNNING_INITIAL_STATE,
   isVisible: IS_VISIBLE_INITIAL_STATE,
   name: NAME_INITIAL_STATE,
@@ -67,7 +67,7 @@ const rootReducer = (state, action) => {
   if (action.type === RESET) {
     return {
       ...state,
-      INITIAL_STATE
+      ...INITIAL_STATE
     };
   } else if (action.type === OPEN) {
     return {

--- a/src/modules/create-view/index.js
+++ b/src/modules/create-view/index.js
@@ -1,0 +1,143 @@
+import { combineReducers } from 'redux';
+import dataService from 'modules/data-service';
+
+import source, {
+  INITIAL_STATE as SOURCE_INITIAL_STATE
+} from 'modules/create-view/source';
+
+import pipeline, {
+  INITIAL_STATE as PIPELINE_INITIAL_STATE
+} from 'modules/create-view/pipeline';
+
+import isRunning, {
+  toggleIsRunning,
+  INITIAL_STATE as IS_RUNNING_INITIAL_STATE
+} from 'modules/create-view/is-running';
+import isVisible, {
+  INITIAL_STATE as IS_VISIBLE_INITIAL_STATE
+} from 'modules/create-view/is-visible';
+import name, {
+  INITIAL_STATE as NAME_INITIAL_STATE
+} from 'modules/create-view/name';
+
+import error, {
+  clearError,
+  handleError,
+  INITIAL_STATE as ERROR_INITIAL_STATE
+} from 'modules/create-view/error';
+
+import { reset, RESET } from 'modules/create-view/reset';
+
+/**
+ * Open action name.
+ */
+const OPEN = 'aggregations/create-view/OPEN';
+
+const INITIAL_STATE = {
+  isRunning: IS_RUNNING_INITIAL_STATE,
+  isVisible: IS_VISIBLE_INITIAL_STATE,
+  name: NAME_INITIAL_STATE,
+  error: ERROR_INITIAL_STATE,
+  source: SOURCE_INITIAL_STATE,
+  pipeline: PIPELINE_INITIAL_STATE
+};
+
+/**
+ * The main reducer.
+ */
+const reducer = combineReducers({
+  isRunning,
+  isVisible,
+  name,
+  error,
+  source,
+  pipeline,
+  dataService
+});
+
+/**
+ * The root reducer.
+ *
+ * @param {Object} state - The state.
+ * @param {Object} action - The action.
+ *
+ * @returns {Object} The new state.
+ */
+const rootReducer = (state, action) => {
+  if (action.type === RESET) {
+    return {
+      ...state,
+      INITIAL_STATE
+    };
+  } else if (action.type === OPEN) {
+    return {
+      ...state,
+      ...INITIAL_STATE,
+      isVisible: true,
+      source: action.source,
+      pipeline: action.pipeline
+    };
+  }
+  return reducer(state, action);
+};
+
+export default rootReducer;
+
+/**
+ * Stop progress and set the error.
+ *
+ * @param {Function} dispatch - The dispatch function.
+ * @param {Error} err - The error.
+ *
+ * @return {Object} The result.
+ */
+const stopWithError = (dispatch, err) => {
+  dispatch(toggleIsRunning(false));
+  return dispatch(handleError(err));
+};
+
+/**
+ * Open create view action creator.
+ *
+ * @param {String} sourceNs - The source namespace for the view.
+ * @param {Array} sourcePipeline - The pipeline to use for the view.
+ * @returns {Object} The action.
+ */
+export const open = (sourceNs, sourcePipeline) => ({
+  type: OPEN,
+  source: sourceNs,
+  pipeline: sourcePipeline
+});
+
+/**
+ * The create view action.
+ *
+ * @returns {Function} The thunk function.
+ */
+export const createView = () => {
+  return (dispatch, getState) => {
+    const state = getState();
+    const ds = state.dataService.dataService;
+
+    const viewName = state.name;
+    const viewSource = state.source;
+    const viewPipeline = state.pipeline;
+    const options = {};
+
+    dispatch(clearError());
+
+    try {
+      dispatch(toggleIsRunning(true));
+
+      ds.createView(viewName, viewSource, viewPipeline, options, (e) => {
+        if (e) {
+          return stopWithError(dispatch, e);
+        }
+        global.hadronApp.appRegistry.emit('refresh-data');
+        dispatch(reset());
+      });
+    } catch (e) {
+      return stopWithError(dispatch, e);
+    }
+  };
+};

--- a/src/modules/create-view/index.spec.js
+++ b/src/modules/create-view/index.spec.js
@@ -1,0 +1,48 @@
+import reducer, { createView, INITIAL_STATE } from 'modules/create-view';
+import { reset } from 'modules/create-view/reset';
+import { CLEAR_ERROR, HANDLE_ERROR } from 'modules/create-view/error';
+
+describe('create database module', () => {
+  describe('#reducer', () => {
+    describe('when an action is provided', () => {
+      describe('when the action is reset', () => {
+        const dataService = 'data-service';
+
+        it('returns the reset state', () => {
+          expect(reducer({ dataService: dataService }, reset())).to.deep.equal({
+            ...INITIAL_STATE
+          });
+        });
+      });
+    });
+  });
+
+  describe('#createView', () => {
+    describe('when no error exists in the state', () => {
+      describe('when the source is invalid', () => {
+        const dispatchSpy = sinon.spy();
+        const getState = () => ({
+          name: 'myView',
+          source: 'dataService',
+          pipeline: [
+            {
+              $project: {
+                a: 1
+              }
+            }
+          ],
+          dataService: { dataService: 'ds' }
+        });
+
+        before(() => {
+          createView()(dispatchSpy, getState);
+        });
+
+        it.skip('dispatches the clear action and handle error actions', () => {
+          expect(dispatchSpy.getCall(0).args[0].type).to.equal(CLEAR_ERROR);
+          expect(dispatchSpy.getCall(1).args[0].type).to.equal(HANDLE_ERROR);
+        });
+      });
+    });
+  });
+});

--- a/src/modules/create-view/index.spec.js
+++ b/src/modules/create-view/index.spec.js
@@ -2,7 +2,7 @@ import reducer, { createView, INITIAL_STATE } from 'modules/create-view';
 import { reset } from 'modules/create-view/reset';
 import { CLEAR_ERROR, HANDLE_ERROR } from 'modules/create-view/error';
 
-describe('create database module', () => {
+describe('create view module', () => {
   describe('#reducer', () => {
     describe('when an action is provided', () => {
       describe('when the action is reset', () => {
@@ -10,7 +10,8 @@ describe('create database module', () => {
 
         it('returns the reset state', () => {
           expect(reducer({ dataService: dataService }, reset())).to.deep.equal({
-            ...INITIAL_STATE
+            ...INITIAL_STATE,
+            dataService: dataService
           });
         });
       });

--- a/src/modules/create-view/is-running.js
+++ b/src/modules/create-view/is-running.js
@@ -1,0 +1,25 @@
+/**
+ * Toggle is running action name.
+ */
+export const TOGGLE_IS_RUNNING = 'aggregations/create-view/is-running/TOGGLE_IS_RUNNING';
+
+export const INITIAL_STATE = false;
+
+export default function reducer(state = INITIAL_STATE, action) {
+  if (action.type === TOGGLE_IS_RUNNING) {
+    return action.isRunning;
+  }
+  return state;
+}
+
+/**
+ * The toggle is running action creator.
+ *
+ * @param {Boolean} isRunning - Is running.
+ *
+ * @returns {Object} The action.
+ */
+export const toggleIsRunning = (isRunning) => ({
+  type: TOGGLE_IS_RUNNING,
+  isRunning: isRunning
+});

--- a/src/modules/create-view/is-visible.js
+++ b/src/modules/create-view/is-visible.js
@@ -1,0 +1,15 @@
+export const TOGGLE_IS_VISIBLE =
+  'aggregations/create-view/is-visible/TOGGLE_IS_VISIBLE';
+
+export const INITIAL_STATE = false;
+
+export default function reducer(state = INITIAL_STATE, action) {
+  if (action.type === TOGGLE_IS_VISIBLE) {
+    return action.isVisible;
+  }
+  return state;
+}
+export const toggleIsVisible = (isVisible) => ({
+  type: TOGGLE_IS_VISIBLE,
+  isVisible: isVisible
+});

--- a/src/modules/create-view/name.js
+++ b/src/modules/create-view/name.js
@@ -1,0 +1,22 @@
+export const CHANGE_VIEW_NAME = 'aggregations/create-view/name/CHANGE_NAME';
+
+export const INITIAL_STATE = '';
+
+export default function reducer(state = INITIAL_STATE, action) {
+  if (action.type === CHANGE_VIEW_NAME) {
+    return action.name;
+  }
+  return state;
+}
+
+/**
+ * The change name action creator.
+ *
+ * @param {String} name - The view name.
+ *
+ * @returns {Object} The action.
+ */
+export const changeViewName = (name) => ({
+  type: CHANGE_VIEW_NAME,
+  name: name
+});

--- a/src/modules/create-view/pipeline.js
+++ b/src/modules/create-view/pipeline.js
@@ -1,0 +1,22 @@
+export const SET_VIEW_PIPELINE = 'aggregations/create-view/pipeline/SET';
+
+export const INITIAL_STATE = [];
+
+export default function reducer(state = INITIAL_STATE, action) {
+  if (action.type === SET_VIEW_PIPELINE) {
+    return action.pipeline;
+  }
+  return state;
+}
+
+/**
+ * The set pipeline action creator.
+ *
+ * @param {Array} pipeline - The view's pipeline.
+ *
+ * @returns {Object} The action.
+ */
+export const setViewPipeline = (pipeline) => ({
+  type: SET_VIEW_PIPELINE,
+  pipeline: pipeline
+});

--- a/src/modules/create-view/reset.js
+++ b/src/modules/create-view/reset.js
@@ -1,0 +1,13 @@
+/**
+ * The reset action name.
+ */
+export const RESET = 'aggregations/create-view/reset';
+
+/**
+ * Reset the state action.
+ *
+ * @return {Object} The action creator.
+ */
+export const reset = () => ({
+  type: RESET
+});

--- a/src/modules/create-view/source.js
+++ b/src/modules/create-view/source.js
@@ -1,0 +1,22 @@
+export const SET_VIEW_SOURCE = 'aggregations/create-view/source/SET';
+
+export const INITIAL_STATE = '';
+
+export default function reducer(state = INITIAL_STATE, action) {
+  if (action.type === SET_VIEW_SOURCE) {
+    return action.source;
+  }
+  return state;
+}
+
+/**
+ * The change name action creator.
+ *
+ * @param {String} source - The view source namespace.
+ *
+ * @returns {Object} The action.
+ */
+export const setViewSource = (source) => ({
+  type: SET_VIEW_SOURCE,
+  source: source
+});

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -579,3 +579,19 @@ export const getPipelineFromIndexedDB = (pipelineId) => {
     });
   };
 };
+
+/**
+ * Open create view.
+ *
+ * @returns {Function} The thunk function.
+ */
+export const openCreateView = () => {
+  return (dispatch, getState) => {
+    dispatch(
+      appRegistryEmit('open-create-view', {
+        source: getState().namespace,
+        pipeline: getState().pipeline
+      })
+    );
+  };
+};

--- a/src/stores/create-view.js
+++ b/src/stores/create-view.js
@@ -1,0 +1,28 @@
+import { createStore, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
+import { dataServiceConnected } from 'modules/data-service';
+import reducer, { open } from 'modules/create-view';
+
+const store = createStore(reducer, applyMiddleware(thunk));
+
+store.onActivated = (appRegistry) => {
+  /**
+   * Set the data service in the store when connected.
+   *
+   * @param {Error} error - The error.
+   * @param {DataService} dataService - The data service.
+   */
+  appRegistry.on('data-service-connected', (error, dataService) => {
+    store.dispatch(dataServiceConnected(error, dataService));
+  });
+
+  /**
+   * When needing to create a view from elsewhere, the app registry
+   * event is emitted.
+   */
+  appRegistry.on('open-create-view', (source, pipeline) => {
+    store.dispatch(open(source, pipeline));
+  });
+};
+
+export default store;

--- a/src/stores/create-view.spec.js
+++ b/src/stores/create-view.spec.js
@@ -1,6 +1,6 @@
 import AppRegistry from 'hadron-app-registry';
-import store from 'stores/create-database';
-import { reset } from 'modules/reset';
+import store from 'stores/create-view';
+import { reset } from 'modules/create-view/reset';
 
 describe('CreateViewStore [Store]', () => {
   beforeEach(() => {
@@ -42,13 +42,13 @@ describe('CreateViewStore [Store]', () => {
       });
 
       it('sets the pipeline', () => {
-        expect(store.getState().isVisible).to.deep.equal([
+        expect(store.getState().pipeline).to.deep.equal([
           { $project: { a: 1 } }
         ]);
       });
 
       it('sets the source', () => {
-        expect(store.getState().isVisible).to.equal('dataService.test');
+        expect(store.getState().source).to.equal('dataService.test');
       });
     });
   });

--- a/src/stores/create-view.spec.js
+++ b/src/stores/create-view.spec.js
@@ -1,0 +1,55 @@
+import AppRegistry from 'hadron-app-registry';
+import store from 'stores/create-database';
+import { reset } from 'modules/reset';
+
+describe('CreateViewStore [Store]', () => {
+  beforeEach(() => {
+    store.dispatch(reset());
+  });
+
+  afterEach(() => {
+    store.dispatch(reset());
+  });
+
+  describe('#onActivated', () => {
+    const appRegistry = new AppRegistry();
+
+    before(() => {
+      store.onActivated(appRegistry);
+    });
+
+    describe('when the data service is connected', () => {
+      const ds = 'data-service';
+
+      beforeEach(() => {
+        appRegistry.emit('data-service-connected', null, ds);
+      });
+
+      it('dispatches the data service connected action', () => {
+        expect(store.getState().dataService.dataService).to.equal(ds);
+      });
+    });
+
+    describe('when open create view is emitted', () => {
+      beforeEach(() => {
+        appRegistry.emit('open-create-view', 'dataService.test', [
+          { $project: { a: 1 } }
+        ]);
+      });
+
+      it('dispatches the toggle action', () => {
+        expect(store.getState().isVisible).to.equal(true);
+      });
+
+      it('sets the pipeline', () => {
+        expect(store.getState().isVisible).to.deep.equal([
+          { $project: { a: 1 } }
+        ]);
+      });
+
+      it('sets the source', () => {
+        expect(store.getState().isVisible).to.equal('dataService.test');
+      });
+    });
+  });
+});

--- a/src/utils/configureStore.js
+++ b/src/utils/configureStore.js
@@ -36,3 +36,22 @@ export function configureStore(preloadedState = {}) {
 
   return store;
 }
+
+import rootCreateViewReducer from 'modules/create-view';
+
+export function configureCreateViewStore(preloadedState = {}) {
+  const store = reduxCreateStore(
+    rootCreateViewReducer,
+    preloadedState,
+    composeEnhancers(applyMiddleware(reduxThunk))
+  );
+
+  if (module.hot) {
+    module.hot.accept('modules/create-view', () => {
+      const nextRootReducer = require('../modules/create-view');
+      store.replaceReducer(nextRootReducer);
+    });
+  }
+
+  return store;
+}


### PR DESCRIPTION
# TODO

- [x] `modules/create-view` like [create-database](https://github.com/mongodb-js/compass-databases-ddl/tree/master/src/modules/create-database)
- [x] `components/create-view` modal dialog
- [x] `components/create-view` modal dialog calls `createView()` with loading indicator
- [x] on view created triggers app registry new tab/flash success message
- [x] `components/create-view` modal dialog handles errors from `createView()`
- [x] Save as View is server version aware 
- [x] Layout in storybook all states
- [x] Handle successful create (open in new tab)
- [x] Fit-and-finish against `.sketch`

# Notes

> Observations. Can circle back if/when it comes up.

- Collation input
 - Missing the deployment `isWritable` requirement so will fail with error message instead of graceful disable like we do in other places
- Since I'm in a modal, would be nice to have `source` and `pipeline` somewhere (like a background `Preview` tab?) before I clicks.
- Validation for name server side only

## Create a view

> It is possible to create a View on top of another View
> 
> When the View has been created, Compass will open the new View in the main screen (in a new tab, as soon as tabs are available)

## Error Handling

> When I am trying to create a new View with the same name of an existing View, I want to see a meaningful error message
> 
> When the server returns errors (e.g., the user doesn't have the necessary permissions to create a view), Compass needs to handle the errors nicely

## Add to save dropdown menu

> When the server is older than 3.4, Save as a View is hidden

<img width="728" alt="Screenshot 2019-04-23 12 31 01" src="https://user-images.githubusercontent.com/23074/56599232-22010b80-65c4-11e9-8962-bc774555d75b.png">
<img width="685" alt="Screenshot 2019-04-23 12 29 16" src="https://user-images.githubusercontent.com/23074/56599231-22010b80-65c4-11e9-8fd7-23aa0a0cfbf1.png">

