### PR TITLE
New design for agg builder sprinkles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mongodb-js/compass-aggregations",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mongodb-js/compass-aggregations",
   "productName": "Aggregations plugin",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "apiVersion": "2.0.0",
   "description": "Compass Aggregation Pipeline Builder",
   "main": "lib/index.js",

--- a/src/components/stage-builder-toolbar/stage-builder-toolbar.jsx
+++ b/src/components/stage-builder-toolbar/stage-builder-toolbar.jsx
@@ -12,66 +12,6 @@ import StageOperatorSelect from './stage-operator-select';
 import styles from './stage-builder-toolbar.less';
 
 /**
- * Map stage operators to doc URLS.
- */
-const SPRINKLE_MAPPINGS = {
-  $addFields:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/addFields/#pipe._S_addFields',
-  $bucket:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/bucket/#pipe._S_bucket',
-  $bucketAuto:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/bucketAuto/#pipe._S_bucketAuto',
-  $collStats:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/collStats/#pipe._S_collStats',
-  $count:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/count/#pipe._S_count',
-  $currentOp:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/currentOp/#pipe._S_currentOp',
-  $facet:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/facet/#pipe._S_facet',
-  $geoNear:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/geoNear/#pipe._S_geoNear',
-  $graphLookup:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/graphLookup/#pipe._S_graphLookup',
-  $group:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/group/#pipe._S_group',
-  $indexStats:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/indexStats/#pipe._S_indexStats',
-  $limit:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/limit/#pipe._S_limit',
-  $listLocalSessions:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/listLocalSessions/#pipe._S_listLocalSessions',
-  $listSessions:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/listSessions/#pipe._S_listSessions',
-  $lookup:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/lookup/#pipe._S_lookup',
-  $match:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/match/#pipe._S_match',
-  $merge:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/match/#pipe._S_merge',
-  $out:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/out/#pipe._S_out',
-  $project:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/project/#pipe._S_project',
-  $redact:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/redact/#pipe._S_redact',
-  $replaceRoot:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/replaceRoot/#pipe._S_replaceRoot',
-  $sample:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/sample/#pipe._S_sample',
-  $searchBeta:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/sample/#pipe._S_searchBeta',
-  $skip:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/skip/#pipe._S_skip',
-  $sort:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/sort/#pipe._S_sort',
-  $sortByCount:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/sortByCount/#pipe._S_sortByCount',
-  $unwind:
-    'https://docs.mongodb.com/manual/reference/operator/aggregation/unwind/#pipe._S_unwind'
-};
-
-/**
  * The stage builder toolbar component.
  */
 class StageBuilderToolbar extends PureComponent {
@@ -93,22 +33,6 @@ class StageBuilderToolbar extends PureComponent {
     openLink: PropTypes.func.isRequired,
     runStage: PropTypes.func.isRequired
   };
-
-  /**
-   * Render the info sprinkle.
-   *
-   * @returns {Component} The component.
-   */
-  renderInfoSprinkle() {
-    if (this.props.stageOperator) {
-      return (
-        <InfoSprinkle
-          onClickHandler={this.props.openLink}
-          helpLink={SPRINKLE_MAPPINGS[this.props.stageOperator]}
-        />
-      );
-    }
-  }
 
   /**
    * Renders the stage builder toolbar.
@@ -142,7 +66,6 @@ class StageBuilderToolbar extends PureComponent {
           setIsModified={this.props.setIsModified}
           stageToggled={this.props.stageToggled}
         />
-        {this.renderInfoSprinkle()}
         <div className={classnames(styles['stage-builder-toolbar-right'])}>
           <DeleteStage
             index={this.props.index}

--- a/src/components/stage-preview-toolbar/stage-preview-toolbar.jsx
+++ b/src/components/stage-preview-toolbar/stage-preview-toolbar.jsx
@@ -80,9 +80,10 @@ class StagePreviewToolbar extends PureComponent {
         if (this.props.stageOperator === OUT && this.props.isValid) {
           return `Documents will be saved to the collection: ${decomment(this.props.stageValue)}`;
         }
+        const stageInfo = STAGE_SPRINKLE_MAPPINGS[this.props.stageOperator];
         return (
           <div>
-            <span>Output after {this.props.stageOperator} stage</span>
+            <span>Output after <span onClick={this.props.openLink.bind(this, stageInfo.link)} className={classnames(styles['stage-preview-toolbar-link'])}>{this.props.stageOperator}</span> stage</span>
             {this.renderInfoSprinkle()}
             <span>(Sample of {this.props.count} {this.getWord()})</span>
           </div>

--- a/src/components/stage-preview-toolbar/stage-preview-toolbar.jsx
+++ b/src/components/stage-preview-toolbar/stage-preview-toolbar.jsx
@@ -82,7 +82,13 @@ class StagePreviewToolbar extends PureComponent {
         const stageInfo = STAGE_SPRINKLE_MAPPINGS[this.props.stageOperator];
         return (
           <div>
-            <span>Output after <span onClick={this.props.openLink.bind(this, stageInfo.link)} className={classnames(styles['stage-preview-toolbar-link'])}>{this.props.stageOperator}</span> stage</span>
+            <span>
+              Output after <span
+                onClick={this.props.openLink.bind(this, stageInfo.link)}
+                className={classnames(styles['stage-preview-toolbar-link'])}>
+                  {this.props.stageOperator}
+                </span> stage
+            </span>
             {this.renderInfoSprinkle(stageInfo)}
             <span>(Sample of {this.props.count} {this.getWord()})</span>
           </div>

--- a/src/components/stage-preview-toolbar/stage-preview-toolbar.jsx
+++ b/src/components/stage-preview-toolbar/stage-preview-toolbar.jsx
@@ -41,18 +41,17 @@ class StagePreviewToolbar extends PureComponent {
    *
    * @returns {Component} The component.
    */
-  renderInfoSprinkle() {
+  renderInfoSprinkle(stageInfo) {
     if (this.props.stageOperator) {
-      const sprinkleInfo = STAGE_SPRINKLE_MAPPINGS[this.props.stageOperator];
       return (
         <span
-          data-tip={sprinkleInfo.tooltip}
+          data-tip={stageInfo.tooltip}
           data-for="stage-tooltip"
           data-place="top"
           data-html="true">
           <InfoSprinkle
             onClickHandler={this.props.openLink}
-            helpLink={sprinkleInfo.link}
+            helpLink={stageInfo.link}
           />
           <Tooltip id="stage-tooltip" />
         </span>
@@ -84,7 +83,7 @@ class StagePreviewToolbar extends PureComponent {
         return (
           <div>
             <span>Output after <span onClick={this.props.openLink.bind(this, stageInfo.link)} className={classnames(styles['stage-preview-toolbar-link'])}>{this.props.stageOperator}</span> stage</span>
-            {this.renderInfoSprinkle()}
+            {this.renderInfoSprinkle(stageInfo)}
             <span>(Sample of {this.props.count} {this.getWord()})</span>
           </div>
         );

--- a/src/components/stage-preview-toolbar/stage-preview-toolbar.jsx
+++ b/src/components/stage-preview-toolbar/stage-preview-toolbar.jsx
@@ -2,6 +2,8 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import decomment from 'decomment';
+import { InfoSprinkle } from 'hadron-react-components';
+import { Tooltip } from 'hadron-react-components';
 import { OUT } from 'modules/pipeline';
 
 import styles from './stage-preview-toolbar.less';
@@ -16,6 +18,10 @@ const ZERO_STATE = 'A sample of the aggregated results from this stage will be s
  */
 const DISABLED = 'Stage is disabled. Results not passed in the pipeline.';
 
+import {
+  STAGE_SPRINKLE_MAPPINGS
+} from '../../constants';
+
 /**
  * The stage preview toolbar component.
  */
@@ -26,7 +32,32 @@ class StagePreviewToolbar extends PureComponent {
     isValid: PropTypes.bool.isRequired,
     stageOperator: PropTypes.string,
     stageValue: PropTypes.any,
-    count: PropTypes.number.isRequired
+    count: PropTypes.number.isRequired,
+    openLink: PropTypes.func.isRequired
+  }
+
+  /**
+   * Render the info sprinkle.
+   *
+   * @returns {Component} The component.
+   */
+  renderInfoSprinkle() {
+    if (this.props.stageOperator) {
+      const sprinkleInfo = STAGE_SPRINKLE_MAPPINGS[this.props.stageOperator];
+      return (
+        <span
+          data-tip={sprinkleInfo.tooltip}
+          data-for="stage-tooltip"
+          data-place="top"
+          data-html="true">
+          <InfoSprinkle
+            onClickHandler={this.props.openLink}
+            helpLink={sprinkleInfo.link}
+          />
+          <Tooltip id="stage-tooltip" />
+        </span>
+      );
+    }
   }
 
   /**
@@ -49,7 +80,13 @@ class StagePreviewToolbar extends PureComponent {
         if (this.props.stageOperator === OUT && this.props.isValid) {
           return `Documents will be saved to the collection: ${decomment(this.props.stageValue)}`;
         }
-        return `Output after ${this.props.stageOperator} stage (Sample of ${this.props.count} ${this.getWord()})`;
+        return (
+          <div>
+            <span>Output after {this.props.stageOperator} stage</span>
+            {this.renderInfoSprinkle()}
+            <span>(Sample of {this.props.count} {this.getWord()})</span>
+          </div>
+        );
       }
       return ZERO_STATE;
     }

--- a/src/components/stage-preview-toolbar/stage-preview-toolbar.less
+++ b/src/components/stage-preview-toolbar/stage-preview-toolbar.less
@@ -23,4 +23,10 @@
       }
     }
   }
+  :global {
+    #stage-tooltip {
+      width: 300px;
+      white-space: pre-wrap;
+    }
+  }
 }

--- a/src/components/stage-preview-toolbar/stage-preview-toolbar.less
+++ b/src/components/stage-preview-toolbar/stage-preview-toolbar.less
@@ -5,4 +5,22 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+
+  :global {
+    i.info-sprinkle {
+      display: inline-block;
+      font: normal normal normal 14px/1 FontAwesome;
+      font-size: inherit;
+      text-rendering: auto;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      margin: 0 5px;
+      cursor: pointer;
+      color: #bfbfbe;
+
+      &:before {
+        content: "\f05a";
+      }
+    }
+  }
 }

--- a/src/components/stage-preview-toolbar/stage-preview-toolbar.less
+++ b/src/components/stage-preview-toolbar/stage-preview-toolbar.less
@@ -1,3 +1,5 @@
+@import (reference) "~less/compass/_theme.less";
+
 .stage-preview-toolbar {
   width: 100%;
   margin-left: 25px;
@@ -5,6 +7,12 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+
+  &-link {
+    text-decoration: underline;
+    cursor: pointer;
+    color: @blue3;
+  }
 
   :global {
     i.info-sprinkle {
@@ -22,8 +30,7 @@
         content: "\f05a";
       }
     }
-  }
-  :global {
+
     #stage-tooltip {
       width: 300px;
       white-space: pre-wrap;

--- a/src/components/stage-preview-toolbar/stage-preview-toolbar.spec.js
+++ b/src/components/stage-preview-toolbar/stage-preview-toolbar.spec.js
@@ -11,6 +11,7 @@ describe('StagePreviewToolbar [Component]', () => {
     beforeEach(() => {
       component = shallow(
         <StagePreviewToolbar
+          openLink={sinon.spy()}
           stageOperator="$match"
           isValid
           count={10}
@@ -24,7 +25,19 @@ describe('StagePreviewToolbar [Component]', () => {
 
     it('renders the stage text', () => {
       expect(component.find(`.${styles['stage-preview-toolbar']}`)).
-        to.have.text('Output after $match stage (Sample of 10 documents)');
+        to.include.text('(Sample of 10 documents)');
+    });
+
+    it('renders the stage text with the right link', () => {
+      expect(component.find(`.${styles['stage-preview-toolbar-link']}`)).
+        to.have.text('$match');
+    });
+
+    it('renders the info sprinkle', () => {
+      expect(component.find(`InfoSprinkle`)).
+        to.be.present()
+      expect(component.find(`InfoSprinkle`).prop('helpLink')).
+        to.include('/aggregation/match')
     });
   });
 

--- a/src/components/stage-toolbar/stage-toolbar.jsx
+++ b/src/components/stage-toolbar/stage-toolbar.jsx
@@ -63,7 +63,8 @@ class StageToolbar extends PureComponent {
           isValid={this.props.isValid}
           stageOperator={this.props.stageOperator}
           stageValue={this.props.stage}
-          count={this.props.previewCount} />
+          count={this.props.previewCount}
+          openLink={this.props.openLink} />
       </div>
     );
   }

--- a/src/constants.js
+++ b/src/constants.js
@@ -63,3 +63,117 @@ export const TOOLTIP_EXPORT_TO_LANGUAGE = 'Export pipeline code to language';
 export const TOOLTIP_CREATE_NEW_PIPELINE = 'Create new pipeline';
 
 export const TOOLTIP_OPEN_SAVED_PIPELINES = 'Open saved Pipelines';
+
+/**
+ * Map stage operators to doc URLS.
+ */
+export const STAGE_SPRINKLE_MAPPINGS = {
+  $addFields: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/addFields/#pipe._S_addFields',
+    tooltip: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit,<br />sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.<br />Ut enim ad minim veniam, quis nostrud exercitation<br />ullamco laboris nisi ut aliquip ex ea commodo consequat.'
+  },
+  $bucket: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/bucket/#pipe._S_bucket',
+    tooltip: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit,<br />sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.<br />Ut enim ad minim veniam, quis nostrud exercitation<br />ullamco laboris nisi ut aliquip ex ea commodo consequat.'
+  },
+  $bucketAuto: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/bucketAuto/#pipe._S_bucketAuto',
+    tooltip: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
+  },
+  $collStats: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/collStats/#pipe._S_collStats',
+    tooltip: ''
+  },
+  $count: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/count/#pipe._S_count',
+    tooltip: ''
+  },
+  $currentOp: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/currentOp/#pipe._S_currentOp',
+    tooltip: ''
+  },
+  $facet: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/facet/#pipe._S_facet',
+    tooltip: ''
+  },
+  $geoNear: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/geoNear/#pipe._S_geoNear',
+    tooltip: ''
+  },
+  $graphLookup: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/graphLookup/#pipe._S_graphLookup',
+    tooltip: ''
+  },
+  $group: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/group/#pipe._S_group',
+    tooltip: ''
+  },
+  $indexStats: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/indexStats/#pipe._S_indexStats',
+    tooltip: ''
+  },
+  $limit: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/limit/#pipe._S_limit',
+    tooltip: ''
+  },
+  $listLocalSessions: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/listLocalSessions/#pipe._S_listLocalSessions',
+    tooltip: ''
+  },
+  $listSessions: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/listSessions/#pipe._S_listSessions',
+    tooltip: ''
+  },
+  $lookup: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/lookup/#pipe._S_lookup',
+    tooltip: ''
+  },
+  $match: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/match/#pipe._S_match',
+    tooltip: ''
+  },
+  $merge: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/match/#pipe._S_merge',
+    tooltip: ''
+  },
+  $out: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/out/#pipe._S_out',
+    tooltip: ''
+  },
+  $project: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/project/#pipe._S_project',
+    tooltip: ''
+  },
+  $redact: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/redact/#pipe._S_redact',
+    tooltip: ''
+  },
+  $replaceRoot: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/replaceRoot/#pipe._S_replaceRoot',
+    tooltip: ''
+  },
+  $sample: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/sample/#pipe._S_sample',
+    tooltip: ''
+  },
+  $searchBeta: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/sample/#pipe._S_searchBeta',
+    tooltip: ''
+  },
+  $skip: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/skip/#pipe._S_skip',
+    tooltip: ''
+  },
+  $sort: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/sort/#pipe._S_sort',
+    tooltip: ''
+  },
+  $sortByCount: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/sortByCount/#pipe._S_sortByCount',
+    tooltip: ''
+  },
+  $unwind: {
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/unwind/#pipe._S_unwind',
+    tooltip: ''
+  }
+};

--- a/src/constants.js
+++ b/src/constants.js
@@ -70,23 +70,23 @@ export const TOOLTIP_OPEN_SAVED_PIPELINES = 'Open saved Pipelines';
 export const STAGE_SPRINKLE_MAPPINGS = {
   $addFields: {
     link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/addFields/#pipe._S_addFields',
-    tooltip: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit,<br />sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.<br />Ut enim ad minim veniam, quis nostrud exercitation<br />ullamco laboris nisi ut aliquip ex ea commodo consequat.'
+    tooltip: 'Adds new field(s) to a document with a computed value, or reassigns an existing field(s) with a computed value.'
   },
   $bucket: {
     link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/bucket/#pipe._S_bucket',
-    tooltip: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit,<br />sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.<br />Ut enim ad minim veniam, quis nostrud exercitation<br />ullamco laboris nisi ut aliquip ex ea commodo consequat.'
+    tooltip: 'Categorizes incoming documents into groups, called buckets, based on specified boundaries.'
   },
   $bucketAuto: {
     link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/bucketAuto/#pipe._S_bucketAuto',
-    tooltip: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
+    tooltip: 'Automatically categorizes documents into a specified number of buckets, attempting even distribution if possible.'
   },
   $collStats: {
     link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/collStats/#pipe._S_collStats',
-    tooltip: ''
+    tooltip: 'Returns statistics regarding a collection or view.'
   },
   $count: {
     link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/count/#pipe._S_count',
-    tooltip: ''
+    tooltip: 'Returns a count of the number of documents at this stage of the aggregation pipeline.'
   },
   $currentOp: {
     link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/currentOp/#pipe._S_currentOp',
@@ -94,27 +94,27 @@ export const STAGE_SPRINKLE_MAPPINGS = {
   },
   $facet: {
     link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/facet/#pipe._S_facet',
-    tooltip: ''
+    tooltip: 'Allows for multiple parellel aggregations to be specified.'
   },
   $geoNear: {
     link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/geoNear/#pipe._S_geoNear',
-    tooltip: ''
+    tooltip: 'Return documents based on proximity to a geospatial point.'
   },
   $graphLookup: {
     link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/graphLookup/#pipe._S_graphLookup',
-    tooltip: ''
+    tooltip: 'Performs a recursive search on a collection. To each output document, adds a new array field that contains the traversal results of the recursive search for that document.'
   },
   $group: {
     link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/group/#pipe._S_group',
-    tooltip: ''
+    tooltip: 'Groups documents by a specified expression.'
   },
   $indexStats: {
     link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/indexStats/#pipe._S_indexStats',
-    tooltip: ''
+    tooltip: 'Returns statistics regarding the use of each index for the collection.'
   },
   $limit: {
     link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/limit/#pipe._S_limit',
-    tooltip: ''
+    tooltip: 'Limits the number of documents that flow into subsequent stages'
   },
   $listLocalSessions: {
     link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/listLocalSessions/#pipe._S_listLocalSessions',
@@ -126,11 +126,11 @@ export const STAGE_SPRINKLE_MAPPINGS = {
   },
   $lookup: {
     link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/lookup/#pipe._S_lookup',
-    tooltip: ''
+    tooltip: 'Performs a join between two collections.'
   },
   $match: {
     link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/match/#pipe._S_match',
-    tooltip: ''
+    tooltip: 'Filters the document stream to allow only matching documents to pass through to subsequent stages.'
   },
   $merge: {
     link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/match/#pipe._S_merge',
@@ -138,23 +138,23 @@ export const STAGE_SPRINKLE_MAPPINGS = {
   },
   $out: {
     link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/out/#pipe._S_out',
-    tooltip: ''
+    tooltip: 'Writes the result of a pipeline to a new or existing collection.'
   },
   $project: {
     link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/project/#pipe._S_project',
-    tooltip: ''
+    tooltip: 'Adds new field(s) to a document with a computed value, or reassigns an existing field(s) with a computed value. Unlike $addFields, $project can also remove fields.'
   },
   $redact: {
     link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/redact/#pipe._S_redact',
-    tooltip: ''
+    tooltip: 'Restrict the content for each document based on information stored in the documents themselves'
   },
   $replaceRoot: {
     link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/replaceRoot/#pipe._S_replaceRoot',
-    tooltip: ''
+    tooltip: 'Replaces a document with the specified embedded document.'
   },
   $sample: {
     link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/sample/#pipe._S_sample',
-    tooltip: ''
+    tooltip: 'Randomly selects the specified number of documents from its input.'
   },
   $searchBeta: {
     link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/sample/#pipe._S_searchBeta',
@@ -162,18 +162,18 @@ export const STAGE_SPRINKLE_MAPPINGS = {
   },
   $skip: {
     link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/skip/#pipe._S_skip',
-    tooltip: ''
+    tooltip: 'Skip a specified number of documents before advancing to the next stage'
   },
   $sort: {
     link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/sort/#pipe._S_sort',
-    tooltip: ''
+    tooltip: 'Reorders the document stream by a specified sort key and direction.'
   },
   $sortByCount: {
     link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/sortByCount/#pipe._S_sortByCount',
-    tooltip: ''
+    tooltip: 'Groups incoming documents based on the value of a specified expression, then computes the count of documents in each distinct group.'
   },
   $unwind: {
     link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/unwind/#pipe._S_unwind',
-    tooltip: ''
+    tooltip: 'Outputs a new document for each element in a specified array. '
   }
 };


### PR DESCRIPTION
With this PR we tweak the design of the stage builder so the info sprinkle is moved next to the stage name in the preview area and contains a tooltip that explains in short what the stage does.

~Unit tests are not updated yet.~

![image (5)](https://user-images.githubusercontent.com/761042/63838323-6c810300-c97d-11e9-8d98-af4b8ac0dba7.png)