### PR TITLE
COMPASS-3882 Added 1-liners and updated error banners

### DIFF
--- a/src/assets/less/compass/variables/_palette.less
+++ b/src/assets/less/compass/variables/_palette.less
@@ -1,6 +1,41 @@
 @sidebar-bg: @slate1;
 @sidebar-width: 250px;
 
+/* MongoDB Color Palette 2019 */
+@black: #061621;
+@grayDark3: #21313C;
+@grayDark2: #3D4F58;
+@grayDark1: #5D6C74;
+@grayBase: #9FA1A2;
+@grayLight1: #B8C4C2;
+@grayLight2: #E7EEEC;
+@grayLight3: #F9FBFA;
+@white: #ffffff;
+
+@greenDark3: #0E6834;
+@greenDark2: #116149;
+@greenBase: #13AA52;
+@greenLight2: #C3E7CA;
+@greenLight3: #E4F4E4;
+
+@blueDark3: #0D324F;
+@blueDark2: #1A567E;
+@blueBase: #007CAD;
+@blueLight2: #C5E4F2;
+@blueLight3: #E1F2F6;
+
+@yellowDark3: #543E07;
+@yellowDark2: #86681D;
+@yellowBase: #FFDD49;
+@yellowLight2: #FEF2C8;
+@yellowLight3: #FEF7E3;
+
+@redDark3: #570B08;
+@redDark2: #8F221B;
+@redBase: #CF4A22;
+@redLight2: #F9D3C5;
+@redLight3: #FCEBE2;
+
 /* MongoDB Color Palette */
 /* commented colors have been deprecated */
 @green0: #0E7E3D; 

--- a/src/components/stage-builder-toolbar/stage-builder-toolbar.jsx
+++ b/src/components/stage-builder-toolbar/stage-builder-toolbar.jsx
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { InfoSprinkle } from 'hadron-react-components';
 import DeleteStage from './delete-stage';
 import AddAfterStage from './add-after-stage';
 import ToggleStage from './toggle-stage';

--- a/src/components/stage-editor/stage-editor.less
+++ b/src/components/stage-editor/stage-editor.less
@@ -19,7 +19,7 @@
     border-radius: 3px;
     overflow: hidden;
     background: @redLight3;
-    border: @redLight2;
+    border: 1px solid @redLight2;
     min-height: 20px;
     width: 350px;
     word-break: break-all;
@@ -36,7 +36,7 @@
     border-radius: 3px;
     overflow: hidden;
     background: @yellowLight3;
-    border: @yellowLight2;
+    border: 1px solid @yellowLight2;
     min-height: 20px;
     width: 350px;
     word-break: break-all;

--- a/src/components/stage-editor/stage-editor.less
+++ b/src/components/stage-editor/stage-editor.less
@@ -18,11 +18,12 @@
     padding: 3px 10px 2px 10px;
     border-radius: 3px;
     overflow: hidden;
-    background: #ff473a;
+    background: @redLight3;
+    border: @redLight2;
     min-height: 20px;
     width: 350px;
     word-break: break-all;
-    color: #FFFFFF;
+    color: @redDark2;
     font-size: x-small;
     font-weight: bold;
   }
@@ -34,11 +35,12 @@
     padding: 3px 10px 2px 10px;
     border-radius: 3px;
     overflow: hidden;
-    background: @warningText;
+    background: @yellowLight3;
+    border: @yellowLight2;
     min-height: 20px;
     width: 350px;
     word-break: break-all;
-    color: #FFFFFF;
+    color: @yellowDark2;
     font-size: x-small;
     font-weight: bold;
   }

--- a/src/components/stage-preview-toolbar/stage-preview-toolbar.jsx
+++ b/src/components/stage-preview-toolbar/stage-preview-toolbar.jsx
@@ -37,29 +37,6 @@ class StagePreviewToolbar extends PureComponent {
   }
 
   /**
-   * Render the info sprinkle.
-   *
-   * @returns {Component} The component.
-   */
-  renderInfoSprinkle(stageInfo) {
-    if (this.props.stageOperator) {
-      return (
-        <span
-          data-tip={stageInfo.tooltip}
-          data-for="stage-tooltip"
-          data-place="top"
-          data-html="true">
-          <InfoSprinkle
-            onClickHandler={this.props.openLink}
-            helpLink={stageInfo.link}
-          />
-          <Tooltip id="stage-tooltip" />
-        </span>
-      );
-    }
-  }
-
-  /**
    * Get the word.
    *
    * @returns {String} The word.
@@ -86,8 +63,8 @@ class StagePreviewToolbar extends PureComponent {
               Output after <span
                 onClick={this.props.openLink.bind(this, stageInfo.link)}
                 className={classnames(styles['stage-preview-toolbar-link'])}>
-                  {this.props.stageOperator}
-                </span> stage
+                {this.props.stageOperator}
+              </span> stage
             </span>
             {this.renderInfoSprinkle(stageInfo)}
             <span>(Sample of {this.props.count} {this.getWord()})</span>
@@ -97,6 +74,29 @@ class StagePreviewToolbar extends PureComponent {
       return ZERO_STATE;
     }
     return DISABLED;
+  }
+
+  /**
+   * Render the info sprinkle.
+   *
+   * @returns {Component} The component.
+   */
+  renderInfoSprinkle(stageInfo) {
+    if (this.props.stageOperator) {
+      return (
+        <span
+          data-tip={stageInfo.tooltip}
+          data-for="stage-tooltip"
+          data-place="top"
+          data-html="true">
+          <InfoSprinkle
+            onClickHandler={this.props.openLink}
+            helpLink={stageInfo.link}
+          />
+          <Tooltip id="stage-tooltip" />
+        </span>
+      );
+    }
   }
 
   /**

--- a/src/components/stage-preview-toolbar/stage-preview-toolbar.spec.js
+++ b/src/components/stage-preview-toolbar/stage-preview-toolbar.spec.js
@@ -34,10 +34,10 @@ describe('StagePreviewToolbar [Component]', () => {
     });
 
     it('renders the info sprinkle', () => {
-      expect(component.find(`InfoSprinkle`)).
-        to.be.present()
-      expect(component.find(`InfoSprinkle`).prop('helpLink')).
-        to.include('/aggregation/match')
+      expect(component.find('InfoSprinkle')).
+        to.be.present();
+      expect(component.find('InfoSprinkle').prop('helpLink')).
+        to.include('/aggregation/match');
     });
   });
 

--- a/src/components/stage-toolbar/stage-toolbar.less
+++ b/src/components/stage-toolbar/stage-toolbar.less
@@ -15,7 +15,7 @@
     display: flex;
     align-items: center;
     position: relative;
-    background: rgb(248, 233, 238);
+    background: @redLight3;
     border-bottom: 1px solid @gray6;
     height: 40px;
     width: 100%;

--- a/src/components/stage/stage.less
+++ b/src/components/stage/stage.less
@@ -9,7 +9,7 @@
   background: @pw;
 
   &-errored {
-    border: 1px solid #ff473a;
+    border: 1px solid @redBase;
     border-radius: 4px;
     margin: 0px 15px 15px;
     background: @pw;

--- a/src/constants.js
+++ b/src/constants.js
@@ -133,7 +133,7 @@ export const STAGE_SPRINKLE_MAPPINGS = {
     tooltip: 'Filters the document stream to allow only matching documents to pass through to subsequent stages.'
   },
   $merge: {
-    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/match/#pipe._S_merge',
+    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/merge/#pipe._S_merge',
     tooltip: 'Merges the resulting documents into a collection, optionally overriding existing documents.'
   },
   $out: {
@@ -157,7 +157,7 @@ export const STAGE_SPRINKLE_MAPPINGS = {
     tooltip: 'Randomly selects the specified number of documents from its input.'
   },
   $searchBeta: {
-    link: 'https://docs.mongodb.com/manual/reference/operator/aggregation/sample/#pipe._S_searchBeta',
+    link: 'https://docs.atlas.mongodb.com/reference/full-text-search/query-syntax/#pipe._S_searchBeta',
     tooltip: 'Performs a full-text search on the specified field(s).'
   },
   $skip: {


### PR DESCRIPTION
1. Updated color palette for error banners:

<img width="408" alt="Screen Shot 2019-09-05 at 5 15 41 PM" src="https://user-images.githubusercontent.com/7270285/64381336-f9246480-d000-11e9-87ea-9451ec33cc4e.png">
<img width="409" alt="Screen Shot 2019-09-05 at 5 16 49 PM" src="https://user-images.githubusercontent.com/7270285/64381337-f9246480-d000-11e9-8495-aa0d41f8463d.png">

2. Added 1-liner for $merge and $searchBeta