### PR TITLE
COMPASS-4263: fix freezing UI with out operator

### DIFF
--- a/src/modules/pipeline.spec.js
+++ b/src/modules/pipeline.spec.js
@@ -23,6 +23,7 @@ import reducer, {
   LOADING_STAGE_RESULTS,
   STAGE_TOGGLED
 } from 'modules/pipeline';
+import { generatePipelineStages } from './pipeline';
 
 const LIMIT_TO_PROCESS = 100000;
 const LIMIT_TO_DISPLAY = 20;
@@ -671,8 +672,15 @@ describe('pipeline module', () => {
         const stage0 = { isEnabled: true, executor: { $out: 'testing' }, stageOperator: '$out' };
         const state = { inputDocuments: { count: 10000 }, pipeline: [ stage0 ]};
 
-        it('returns the pipeline with the current and all previous stages', () => {
+        it('returns the pipeline with the current, all previous stages and limit', () => {
           expect(generatePipeline(state, 0)).to.deep.equal([
+            stage0.executor,
+            limit
+          ]);
+        });
+
+        it('returns the pipeline stages with the current and all previous stages', () => {
+          expect(generatePipelineStages(state, 0)).to.deep.equal([
             stage0.executor
           ]);
         });


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
The issue described in the ticket https://jira.mongodb.org/browse/COMPASS-4263 happens because of using the `out` operator on the large collection. For aggregations, without `out` we execute pipelines not on the whole collection, but on the subset because of UI performance issues (we can not display so many results in the preview, and it takes a long time to get these results). So we check if the pipeline itself has a limit stage and if not we use a default value for the `limit` operator.

For pipelines with `out` we do not add the `limit` operator as the last stage of the pipeline, because according to design `out` should be the last stage of the pipeline. This exactly what was causing the issue, because the pipeline was running on the whole collection and Compass UI got frozen.

To solve the issue I refactored the `generatePipeline` function and extracted the part responsible for stages generating without adding limit at the end. For preview functionality, I call the `generatePipeline` function with the limit to fix freezing of UI. We can to it at this point because we do not call the `out` part yet. To start exporting results to another collection a user should click the `Save Documents` button, and here I call the `generatePipelineStages` function that is a subfunction of the `generatePipeline` function that is responsible only for stages generating without limiting results.

<img width="1027" alt="Screenshot 2020-07-01 at 14 20 34" src="https://user-images.githubusercontent.com/16307679/86243541-db834580-bba6-11ea-9105-09575fdbc89d.png">

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
