### PR TITLE
COMPASS-4368: Fix error on invalid, not yet run out stage 

### DIFF
--- a/src/components/stage-preview-toolbar/stage-preview-toolbar.jsx
+++ b/src/components/stage-preview-toolbar/stage-preview-toolbar.jsx
@@ -2,7 +2,6 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import decomment from 'decomment';
-import isString from 'lodash.isstring';
 import { InfoSprinkle } from 'hadron-react-components';
 import { Tooltip } from 'hadron-react-components';
 import { OUT } from 'modules/pipeline';
@@ -54,10 +53,17 @@ class StagePreviewToolbar extends PureComponent {
   }
 
   getOutText() {
-    const value = decomment(this.props.stageValue);
-    if (!!value.match(S3_MATCH)) return OUT_S3;
-    if (!!value.match(ATLAS_MATCH)) return OUT_ATLAS;
-    return `${OUT_COLL} ${value}`;
+    try {
+      const value = decomment(this.props.stageValue);
+      if (!!value.match(S3_MATCH)) return OUT_S3;
+      if (!!value.match(ATLAS_MATCH)) return OUT_ATLAS;
+      return `${OUT_COLL} ${value}`;
+    } catch (err) {
+      // The validity check may not have been run yet, in which
+      // case certain inputs like """ may cause decommenting to error.
+      // https://jira.mongodb.org/browse/COMPASS-4368
+      return 'Unable to parse the location for the out stage.';
+    }
   }
 
   /**

--- a/src/components/stage-preview-toolbar/stage-preview-toolbar.jsx
+++ b/src/components/stage-preview-toolbar/stage-preview-toolbar.jsx
@@ -62,7 +62,7 @@ class StagePreviewToolbar extends PureComponent {
       // The validity check may not have been run yet, in which
       // case certain inputs like """ may cause decommenting to error.
       // https://jira.mongodb.org/browse/COMPASS-4368
-      return 'Unable to parse the location for the out stage.';
+      return 'Unable to parse the destination for the out stage.';
     }
   }
 

--- a/src/components/stage-preview-toolbar/stage-preview-toolbar.spec.js
+++ b/src/components/stage-preview-toolbar/stage-preview-toolbar.spec.js
@@ -153,7 +153,7 @@ describe('StagePreviewToolbar [Component]', () => {
 
       it('renders the $out stage text', () => {
         expect(component.find(`.${styles['stage-preview-toolbar']}`)).
-          to.have.text('Unable to parse the location for the out stage.');
+          to.have.text('Unable to parse the destination for the out stage.');
       });
     });
 

--- a/src/components/stage-preview-toolbar/stage-preview-toolbar.spec.js
+++ b/src/components/stage-preview-toolbar/stage-preview-toolbar.spec.js
@@ -132,6 +132,31 @@ describe('StagePreviewToolbar [Component]', () => {
       });
     });
 
+    context('when the value is an invalid string while isValid is true', () => {
+      let component;
+
+      beforeEach(() => {
+        component = shallow(
+          <StagePreviewToolbar
+            openLink={sinon.spy()}
+            stageOperator="$out"
+            stageValue="'''" // 3 single quotes.
+            count={0}
+            isValid
+            isEnabled />
+        );
+      });
+
+      afterEach(() => {
+        component = null;
+      });
+
+      it('renders the $out stage text', () => {
+        expect(component.find(`.${styles['stage-preview-toolbar']}`)).
+          to.have.text('Unable to parse the location for the out stage.');
+      });
+    });
+
     context('when the value is s3', () => {
       context('when the value is a string', () => {
         let component;

--- a/src/modules/pipeline.js
+++ b/src/modules/pipeline.js
@@ -592,7 +592,7 @@ const aggregate = (pipeline, dataService, ns, dispatch, state, index) => {
   if (isEmpty(state.collation) === false) {
     options.collation = state.collation;
   }
-  
+
   dataService.aggregate(ns, pipeline, options, (err, cursor) => {
     if (err) return dispatch(stagePreviewUpdated([], index, err));
     cursor.toArray((e, docs) => {


### PR DESCRIPTION
COMPASS-4368

This PR adds a check around showing the output destination for an out stage. Currently because we rate limit the running and parsing of the stage's input value, there's a chance the input is not valid, while the `isValid` boolean is still true because it has not yet been run. In those situations we know 

I think if we want to add a bit more complexity but be a bit more solid on this going forward we could add a new variable stored on stages which maintains whether the stage has been checked for validity yet on its current input. In which cases we could be a bit cleaner here. Opted for the smaller footprint PR. If the reviewer thinks this would be better I'm totally down to do the fix, will take a bit longer though.

To test the original crashing behavior, having three quotes will cause the same bug as reported in the issue. Now on invalid input this message is shown:
<img width="600" alt="Screen Shot 2020-08-17 at 6 28 01 PM" src="https://user-images.githubusercontent.com/1791149/90419816-65379580-e0b7-11ea-8eb4-47ab2bcfeca7.png">
