### PR TITLE
COMPASS-4355: Update mongodb-query-parser to bring in int64 fix for dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8244,18 +8244,18 @@
       "dev": true
     },
     "ejson-shell-parser": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/ejson-shell-parser/-/ejson-shell-parser-0.0.2.tgz",
-      "integrity": "sha512-86NVl8AP2sDF43LHkPQCUCbER02Dyg3TqTAJ8OHk4lmSdKxD+wG1XRCatfKnLEU+HhFxSACLmHPNeqdRzaDtlw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ejson-shell-parser/-/ejson-shell-parser-1.0.2.tgz",
+      "integrity": "sha512-cXuXDWSrwsNovV8d1wNDvCifiqsj8vk1EyfusI5pWMTvTSVb195z2GMBQ6bgeoVv0or7yCV6aokLBU2aOIWwog==",
       "dev": true,
       "requires": {
-        "acorn": "^7.1.0"
+        "acorn": "^7.4.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
           "dev": true
         }
       }
@@ -17899,14 +17899,14 @@
       "integrity": "sha512-sch/9jd74VjRCmB5U+Fj4WJnkmAtDQgxqJkBInO7zEknXE+lnDEuNBT5/Wp59HMrWUabssGGq08r6Y6F7pkvVA=="
     },
     "mongodb-query-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/mongodb-query-parser/-/mongodb-query-parser-2.0.2.tgz",
-      "integrity": "sha512-Yrc8E21oHXx/uUll9LeQ+LtGyvT0J/2OSuJb6bqjJ2CgxfzKYsAvutRbV+V8um3rIW8pUPhGmcdDjME3nXpHnw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mongodb-query-parser/-/mongodb-query-parser-2.1.2.tgz",
+      "integrity": "sha512-SxzpbwRQ16AgjzVeALz8+MEDILqGALcGbPj+fHmAfJUiQMfWu8zdMb550sMquwGudbgUTuTdjPctHE7NfYzkOA==",
       "dev": true,
       "requires": {
         "bson": "^4.0.3",
         "debug": "^4.1.1",
-        "ejson-shell-parser": "0.0.2",
+        "ejson-shell-parser": "^1.0.2",
         "is-json": "^2.0.1",
         "javascript-stringify": "^2.0.1",
         "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "mongodb-data-service": "^16.0.0",
     "mongodb-js-metrics": "^5.0.0",
     "mongodb-js-precommit": "^2.0.0",
-    "mongodb-query-parser": "^2.0.0",
+    "mongodb-query-parser": "^2.1.2",
     "mongodb-reflux-store": "0.0.1",
     "mongodb-schema": "^8.2.3",
     "mongodb-stitch-browser-sdk": "^4.3.2",


### PR DESCRIPTION
Pulls in https://github.com/mongodb-js/query-parser/commit/46f84f666f4731669d03449b86b0b648ebff4699
Since this package has `mongodb-query-parser` as a peer & dev dependency this change is more for the development in this package. 