### PR TITLE
feat: Add tooltip to stage operator select with stage description

### DIFF
--- a/src/components/stage-builder-toolbar/select-option-with-tooltip/select-option-with-tooltip.jsx
+++ b/src/components/stage-builder-toolbar/select-option-with-tooltip/select-option-with-tooltip.jsx
@@ -1,0 +1,32 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Tooltip } from 'hadron-react-components';
+import { Option } from 'react-select-plus';
+
+import styles from './select-option-with-tooltip.less';
+
+class SelectOptionWithTooltip extends Component {
+  static propTypes = {
+    option: PropTypes.object
+  };
+
+  render() {
+    const { option } = this.props;
+
+    return (
+      <div
+        data-tip={option.description}
+        data-place="right"
+        data-for={`select-option-${option.name}`}
+      >
+        <Option {...this.props} />
+        <Tooltip
+          className={styles.tooltip}
+          id={`select-option-${option.name}`}
+        />
+      </div>
+    );
+  }
+}
+
+export default SelectOptionWithTooltip;

--- a/src/components/stage-builder-toolbar/select-option-with-tooltip/select-option-with-tooltip.less
+++ b/src/components/stage-builder-toolbar/select-option-with-tooltip/select-option-with-tooltip.less
@@ -1,0 +1,3 @@
+.tooltip {
+  max-width: 340px !important;
+}

--- a/src/components/stage-builder-toolbar/select-option-with-tooltip/select-option-with-tooltip.spec.js
+++ b/src/components/stage-builder-toolbar/select-option-with-tooltip/select-option-with-tooltip.spec.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Tooltip } from 'hadron-react-components';
+import { Option } from 'react-select-plus';
+
+import SelectOptionWithTooltip from './select-option-with-tooltip';
+
+describe('SelectOptionWithTooltip [Component]', () => {
+  let component;
+
+  beforeEach(() => {
+    component = mount(
+      <SelectOptionWithTooltip
+        option={{
+          value: 'a',
+          label: 'a'
+        }}
+      />
+    );
+  });
+
+  afterEach(() => {
+    component = null;
+  });
+
+  it('renders the tooltip', () => {
+    expect(component.find(Option)).to.be.present();
+  });
+
+  it('renders the react-select-plus option', () => {
+    expect(component.find(Tooltip)).to.be.present();
+  });
+});

--- a/src/components/stage-builder-toolbar/select-option-with-tooltip/select-option-with-tooltip.spec.js
+++ b/src/components/stage-builder-toolbar/select-option-with-tooltip/select-option-with-tooltip.spec.js
@@ -24,10 +24,10 @@ describe('SelectOptionWithTooltip [Component]', () => {
   });
 
   it('renders the tooltip', () => {
-    expect(component.find(Option)).to.be.present();
+    expect(component.find(Tooltip)).to.be.present();
   });
 
   it('renders the react-select-plus option', () => {
-    expect(component.find(Tooltip)).to.be.present();
+    expect(component.find(Option)).to.be.present();
   });
 });

--- a/src/components/stage-builder-toolbar/stage-operator-select.jsx
+++ b/src/components/stage-builder-toolbar/stage-operator-select.jsx
@@ -1,9 +1,10 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 import semver from 'semver';
 import Select from 'react-select-plus';
 import { STAGE_OPERATORS } from 'mongodb-ace-autocompleter';
+
+import SelectOptionWithTooltip from './select-option-with-tooltip/select-option-with-tooltip';
 
 import styles from './stage-operator-select.less';
 
@@ -70,18 +71,20 @@ class StageOperatorSelect extends PureComponent {
         this.isSupportedEnv(o.env, this.props.env);
     });
     return (
-      <div className={classnames(styles['stage-operator-select'])}>
+      <div className={styles['stage-operator-select']}>
         <Select
+          optionComponent={SelectOptionWithTooltip}
           simpleValue
           searchable
           openOnClick
           openOnFocus
           clearable={false}
           disabled={!this.props.isEnabled}
-          className={classnames(styles['stage-operator-select-control'])}
+          className={styles['stage-operator-select-control']}
           options={operators}
           value={this.props.stageOperator}
-          onChange={this.onStageOperatorSelected} />
+          onChange={this.onStageOperatorSelected}
+        />
       </div>
     );
   }


### PR DESCRIPTION
This PR adds a tooltip to the stage operator options in the stage select dropdown.

The descriptions are from https://github.com/mongodb-js/ace-autocompleter/blob/master/lib/constants/stage-operators.js

![aggregation stage tooltip](https://user-images.githubusercontent.com/1791149/98915202-e2fa1a00-24c9-11eb-91e2-156763ae963a.gif)
