### PR TITLE
Compass 4528: Upgrade compass-aggregations to react-ace@9.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -874,16 +874,6 @@
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
-    "@babel/polyfill": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.8.3.tgz",
-      "integrity": "sha512-0QEgn2zkCzqGIkSWWAEmvxD7e00Nm9asTtQvi7HdlYvMhjy/J38V/1Y9ode0zEJeIuxAI0uftiAzqc7nVeWUGg==",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.2"
-      }
-    },
     "@babel/preset-env": {
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.8.4.tgz",
@@ -2848,6 +2838,12 @@
         "mime-types": "~2.1.24",
         "negotiator": "0.6.2"
       }
+    },
+    "ace-builds": {
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.4.12.tgz",
+      "integrity": "sha512-G+chJctFPiiLGvs3+/Mly3apXTcfgE45dT5yp12BcWZ1kUs+gm0qd3/fv4gsz6fVag4mM0moHVpjHDIgph6Psg==",
+      "dev": true
     },
     "acorn": {
       "version": "5.7.4",
@@ -7888,9 +7884,9 @@
       "dev": true
     },
     "diff-match-patch": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.4.tgz",
-      "integrity": "sha512-Uv3SW8bmH9nAtHKaKSanOQmj2DnlH65fUpcrMdfdaOxUG02QQ4YGZ8AE7kKOMisF7UqvOlGKVYWRvezdncW9lg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
       "dev": true
     },
     "diffie-hellman": {
@@ -20740,13 +20736,12 @@
       }
     },
     "react-ace": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-6.6.0.tgz",
-      "integrity": "sha512-Jehhp8bxa8kqiXk07Jzy+uD5qZMBwo43O+raniGHjdX7Qk93xFkKaAz8LxtUVZPJGlRnV5ODMNj0qHwDSN+PBw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-8.1.0.tgz",
+      "integrity": "sha512-n3rm9gRNZjLGlXJQ587RASOQCPn6WlcV2gjRYwvG3gyVpBf4pY6lh/uI9tDkx2zYdEKJUfnGbTmzEGL5yyDWuw==",
       "dev": true,
       "requires": {
-        "@babel/polyfill": "^7.4.4",
-        "brace": "^0.11.1",
+        "ace-builds": "^1.4.6",
         "diff-match-patch": "^1.0.4",
         "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20736,9 +20736,9 @@
       }
     },
     "react-ace": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-8.1.0.tgz",
-      "integrity": "sha512-n3rm9gRNZjLGlXJQ587RASOQCPn6WlcV2gjRYwvG3gyVpBf4pY6lh/uI9tDkx2zYdEKJUfnGbTmzEGL5yyDWuw==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-9.2.0.tgz",
+      "integrity": "sha512-vuxDt/8+szWsS8TdrgChRk9TFrbHCrzCUvAb2fRN9iziQZwwHYgFQfaUcnv/+7gysK/pJng9Zeuh3svEweiKwg==",
       "dev": true,
       "requires": {
         "ace-builds": "^1.4.6",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
-    "react-ace": "^6.4.0",
+    "react-ace": "^8.1.0",
     "react-bootstrap": "^0.32.4"
   },
   "devDependencies": {
@@ -151,7 +151,7 @@
     "pre-commit": "^1.2.2",
     "prop-types": "^15.7.2",
     "react": "^16.8.0",
-    "react-ace": "^6.4.0",
+    "react-ace": "^8.1.0",
     "react-dom": "^16.8.0",
     "react-hot-loader": "^4.8.0",
     "resolve": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@mongodb-js/compass-field-store": "*",
     "@mongodb-js/compass-export-to-language": "*",
     "async": "^1.5.2",
+    "ace-builds": "1.4.12",
     "bson-transpilers": "^0.13.3",
     "electron": "*",
     "hadron-react-bson": "^4.0.4",
@@ -63,7 +64,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
-    "react-ace": "^8.1.0",
+    "react-ace": "^9.2.0",
     "react-bootstrap": "^0.32.4"
   },
   "devDependencies": {
@@ -76,6 +77,7 @@
     "@storybook/addon-links": "^5.0.3",
     "@storybook/addon-options": "^5.0.3",
     "@storybook/react": "^5.0.3",
+    "ace-builds": "1.4.12",
     "async": "^1.5.2",
     "autoprefixer": "^9.4.10",
     "babel-cli": "^6.26.0",
@@ -151,7 +153,7 @@
     "pre-commit": "^1.2.2",
     "prop-types": "^15.7.2",
     "react": "^16.8.0",
-    "react-ace": "^8.1.0",
+    "react-ace": "^9.2.0",
     "react-dom": "^16.8.0",
     "react-hot-loader": "^4.8.0",
     "resolve": "^1.10.0",

--- a/src/components/pipeline/modals/import-pipeline.jsx
+++ b/src/components/pipeline/modals/import-pipeline.jsx
@@ -2,10 +2,12 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Modal } from 'react-bootstrap';
+import 'ace-builds';
+import 'ace-builds/webpack-resolver';
 import AceEditor from 'react-ace';
+import 'ace-builds/src-noconflict/ext-language_tools';
 import { TextButton } from 'hadron-react-buttons';
 
-import 'brace/ext/language_tools';
 import 'mongodb-ace-mode';
 import 'mongodb-ace-theme';
 

--- a/src/components/stage-editor/stage-editor.jsx
+++ b/src/components/stage-editor/stage-editor.jsx
@@ -1,14 +1,15 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import 'ace-builds';
+import 'ace-builds/webpack-resolver';
 import AceEditor from 'react-ace';
-import ace from 'brace';
+import 'ace-builds/src-noconflict/ext-language_tools';
 import classnames from 'classnames';
 import debounce from 'lodash.debounce';
 import { StageAutoCompleter } from 'mongodb-ace-autocompleter';
 
 import styles from './stage-editor.less';
 
-import 'brace/ext/language_tools';
 import 'mongodb-ace-mode';
 import 'mongodb-ace-theme';
 


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
As part of the 3rd Party HIPPA upgrades for mms, we've upgraded to using the newest (9.2.0) version of react-ace. Because @mongodb-js/compass-aggregations has a peer dependency on the old react-ace version, it will also need to be modified to use the latest react-ace version, which does have some breaking changes.

I've attempted to do the upgrade myself but consistently hit the following (annoyingly minified) error when attempting to render the AggregationsPlugin in mms. If someone with more familiarity with the library could complete and QA this react-ace upgrade, it would unblock our mms upgrade
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
