### PR TITLE
fix: stage names undefined with quotes

### DIFF
--- a/src/modules/extract-stages.js
+++ b/src/modules/extract-stages.js
@@ -61,7 +61,7 @@ function isValidObjectExpression(element) {
 function objectExpressionToStage(objectExpression) {
   const { key: keyNode, value: valueNode } = objectExpression.properties[0];
   return {
-    operator: keyNode.name,
+    operator: keyNode.name || keyNode.value,
     source: generate(valueNode, { comments: true, indent: '  ' })
   };
 }

--- a/src/modules/extract-stages.spec.js
+++ b/src/modules/extract-stages.spec.js
@@ -14,8 +14,18 @@ describe('extractStages', () => {
     }]);
   });
 
-  it('extracts a stage from pipeline text (stage name has quotes)', () => {
+  it('extracts a stage from pipeline text (stage name has double-quotes)', () => {
     const stages = extractStages('[{ "$match": {x: 1} }]');
+    expect(stages).to.deep.equal([{
+      operator: '$match',
+      source: `{
+  x: 1
+}`
+    }]);
+  });
+
+  it('extracts a stage from pipeline text (stage name has single-quotes)', () => {
+    const stages = extractStages('[{ \'$match\': {x: 1} }]');
     expect(stages).to.deep.equal([{
       operator: '$match',
       source: `{

--- a/src/modules/extract-stages.spec.js
+++ b/src/modules/extract-stages.spec.js
@@ -14,6 +14,16 @@ describe('extractStages', () => {
     }]);
   });
 
+  it('extracts a stage from pipeline text (stage name has quotes)', () => {
+    const stages = extractStages('[{ "$match": {x: 1} }]');
+    expect(stages).to.deep.equal([{
+      operator: '$match',
+      source: `{
+  x: 1
+}`
+    }]);
+  });
+
   it('allows an empty array', () => {
     const stages = extractStages('[]');
     expect(stages).to.deep.equal([]);


### PR DESCRIPTION
Fixes stage names being undefined when defined using quotes.

To add support for $function we switched to a less “smart” parser that does not validate stages.

The new js parser represents object properties in different way depending or not they have quotes (https://github.com/estree/estree/blob/master/es5.md#property). 
- if an object property has quotes the parser internally thinks that is a regular string (Literal),
- if it doesn’t it treats it like a variable (Identifier).

Here we handle both cases.