### PR TITLE
fix: hide empty state when loading

### DIFF
--- a/src/components/stage-preview/stage-preview.jsx
+++ b/src/components/stage-preview/stage-preview.jsx
@@ -156,8 +156,12 @@ class StagePreview extends Component {
         );
       }
     }
+    if (this.props.isLoading) {
+      // Don't render the empty state when loading.
+      return;
+    }
     return (
-      <div className={styles['stage-preview-invalid']}>
+      <div className={styles['stage-preview-empty']}>
         <div>
           <svg width="44" height="60" viewBox="0 0 44 60" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M21.9297 38.2988C23.4783 35.1247 27.7679 30.0989 32.5375 35.3879"/>

--- a/src/components/stage-preview/stage-preview.less
+++ b/src/components/stage-preview/stage-preview.less
@@ -8,7 +8,7 @@
   position: relative;
   flex-grow: 1;
 
-  &-invalid {
+  &-empty {
     padding-left: 15px;
     margin: auto;
     overflow: hidden;

--- a/src/components/stage-preview/stage-preview.spec.js
+++ b/src/components/stage-preview/stage-preview.spec.js
@@ -37,6 +37,36 @@ describe('StagePreview [Component]', () => {
     });
   });
 
+  context('when there are no documents', () => {
+    let component;
+
+    beforeEach(() => {
+      component = mount(
+        <StagePreview
+          documents={[]}
+          isValid
+          isEnabled
+          isComplete
+          index={0}
+          runOutStage={sinon.spy()}
+          gotoOutResults={sinon.spy()}
+          gotoMergeResults={sinon.spy()}
+          isLoading={false} />
+      );
+    });
+
+    afterEach(() => {
+      component = null;
+    });
+
+    it('renders an empty state', () => {
+      expect(
+        component.find(`.${styles['stage-preview-empty']}`)
+      ).to.be.present();
+    });
+  });
+
+
   context('when the stage operator is $out', () => {
     context('when the execution is not complete', () => {
       let component;
@@ -186,6 +216,12 @@ describe('StagePreview [Component]', () => {
       it('renders the loading overlay', () => {
         expect(component.find(`.${loadingStyles['loading-overlay-box-text']}`)).
           to.have.text('Loading Preview Documents...');
+      });
+
+      it('does not show the empty state', () => {
+        expect(
+          component.find(`.${styles['stage-preview-empty']}`)
+        ).to.not.be.present();
       });
     });
   });


### PR DESCRIPTION
Before:
<img width="506" alt="Screen Shot 2021-04-06 at 1 53 36 PM" src="https://user-images.githubusercontent.com/1791149/113756585-92d15d80-96df-11eb-9597-7dad462bf12e.png">


After:
<img width="428" alt="Screen Shot 2021-04-06 at 1 53 52 PM" src="https://user-images.githubusercontent.com/1791149/113756577-906f0380-96df-11eb-86f0-c4e27cd6105b.png">
